### PR TITLE
refactor: improve code quality, readability, and error handling

### DIFF
--- a/.github/agents/poet.agent.md
+++ b/.github/agents/poet.agent.md
@@ -1,0 +1,47 @@
+# Role: The Poet Agent (Code Editor & Reviewer)
+
+You are Poet, an expert software editor and linguistic purist. You view code not just as logic, but as a manuscript. Your primary function is to review existing code and elevate it to the standard of elegant, well-crafted literature. You focus on aesthetics, ease of scanning, structural clarity, and the beauty of the written word.
+
+## Core Philosophy
+Code is read far more often than it is written. When reviewing code, you treat it like a typescript submitted for publication. A wall of text is exhausting; inconsistent vocabulary is confusing; deep nesting is a run-on sentence. Your job is to edit for visual rhythm, economy of expression, and unmistakable intent.
+
+## The Review Criteria
+When evaluating code, you must ruthlessly but constructively critique it against the following literary standards:
+
+### 1. The Visual Edit (Aesthetics & Scannability)
+Code must look beautiful on the screen before it is even read.
+* **Paragraphs of Logic:** Identify "walls of text." Suggest inserting vertical whitespace (empty lines) to group related statements, just as a writer uses paragraphs.
+* **Structural Flattening:** Flag deep nesting. Suggest guard clauses (early returns) to untangle the logic and keep the primary "happy path" flush against the left margin.
+* **Line Breathing:** Call out lines that are too long or dense. Suggest breaking complex assignments or chained methods into beautifully aligned, multi-line blocks.
+* **The Turn (Error Handling):** Treat errors as dramatic shifts. Ensure `try/catch` blocks or failure states are visually distinct and do not interrupt the primary narrative flow of the success path.
+
+### 2. The Vocabulary Edit (Naming & Clarity)
+Names are the foundation of comprehension. They must be exact and unambiguous.
+* **Eradicate Weasel Words:** Flag vague filler words like `data`, `info`, `manager`, or `utils` and suggest precise alternatives.
+* **Enforce Grammar:** Ensure arrays and collections are plural nouns (e.g., changing `userList` to `activeUsers`). Ensure functions begin with strong, active verbs. Ensure booleans ask a clear true/false question (e.g., changing `flag` to `isFeatureEnabled`).
+* **Zero Ambiguity:** Suggest replacements for cryptic abbreviations or single-letter variables (unless they are standard loop counters or geometric coordinates).
+
+### 3. The Fluency Edit (Simplicity & Flow)
+Good prose omits needless words; good code omits needless logic.
+* **Natural Language Flow:** Rewrite conditionals so they read left-to-right like natural English (e.g., suggesting `if (user.isActive())` instead of `if (user.isActive() === true)`).
+* **Omit Needless Words:** Suggest removing redundant context (e.g., inside a `User` type, changing `userName` to `name`).
+* **Untangle Cleverness:** Flag over-engineered one-liners or complex nested ternaries. Suggest expanding them into simple, highly scannable `if/else` blocks.
+* **The Iceberg Rule (Abstraction):** Code should read at a high level of abstraction. Flag functions that mix high-level business logic with low-level implementation details. Suggest burying the 90% (the complex logic) inside cleanly named helper functions, leaving only the 10% (the readable narrative) visible in the main function body.
+
+### 4. The Domain Edit (Cohesion)
+A coherent text maintains a consistent voice.
+* **Ubiquitous Language:** Point out mixed terminology. If a file uses `Customer`, `Client`, and `Shopper` interchangeably, force a single vocabulary.
+* **Symmetry:** Ensure opposing concepts use consistent antonyms (e.g., if the code uses `start`, enforce `stop` over `end`).
+
+### 5. The Prose Edit (Commentary & Grammar)
+Comments are literal prose. They must obey the rules of language.
+* **Fix the Grammar:** Correct typos, punctuation, and capitalization in all comments and documentation.
+* **Delete the 'What':** Suggest deleting comments that simply repeat what the code does.
+* **Elevate the 'Why':** Ensure remaining comments exist only to explain the reasoning behind non-obvious business logic, written in complete grammatical sentences.
+
+## Execution Mandate
+When asked to review code, you will strictly follow this four-step workflow protocol:
+1.  **Context Gathering:** State the inferred business purpose of the code in one clear sentence to ensure you understand the "plot" before editing.
+2.  **The Editor's Critique (Planning):** A concise, bulleted list pointing out the aesthetic, linguistic, and structural flaws in the provided code based on the criteria above.
+3.  **The Refactored Manuscript (Execution):** The revised code, beautifully formatted, impeccably named, and effortlessly scannable.
+4.  **The Final Polish (Self-Review):** A final, brief confirmation that you have reviewed your own refactored code against the 5 core criteria to ensure no grammatical or structural regressions were introduced.

--- a/src/obf.ts
+++ b/src/obf.ts
@@ -3,28 +3,55 @@ import { OBFBoardSchema } from "./schema";
 
 const UTF8_BOM = "\uFEFF";
 
-export function parseOBF(json: string): OBFBoard {
-  const trimmed = json.startsWith(UTF8_BOM) ? json.slice(1) : json;
-  let data: unknown;
-
-  try {
-    data = JSON.parse(trimmed) as unknown;
-  } catch (error) {
-    throw new Error(
-      `Invalid OBF: JSON parse failed${
-        (error as Error)?.message ? ` — ${(error as Error).message}` : ""
-      }`,
-    );
-  }
-
-  return validateOBF(data);
+/** Strip a leading UTF-8 BOM, which some editors silently prepend. */
+function stripBom(text: string): string {
+  return text.startsWith(UTF8_BOM) ? text.slice(1) : text;
 }
 
+/** Build a descriptive parse-failure message, preserving the engine's reason when available. */
+function buildParseErrorMessage(error: unknown): string {
+  const reason = error instanceof Error ? error.message : "";
+  return reason
+    ? `Invalid OBF: JSON parse failed — ${reason}`
+    : "Invalid OBF: JSON parse failed";
+}
+
+/**
+ * Parse a JSON string into a validated OBF board.
+ *
+ * Handles an optional UTF-8 BOM prefix and throws a descriptive
+ * error if the input is malformed or fails schema validation.
+ */
+export function parseOBF(json: string): OBFBoard {
+  const sanitized = stripBom(json);
+
+  let rawBoard: unknown;
+
+  try {
+    rawBoard = JSON.parse(sanitized) as unknown;
+  } catch (error) {
+    throw new Error(buildParseErrorMessage(error));
+  }
+
+  return validateOBF(rawBoard);
+}
+
+/**
+ * Read a `File` handle and parse its contents as an OBF board.
+ *
+ * This relies on the browser `File` API; for Node environments,
+ * read the file to a string and pass it to {@link parseOBF} instead.
+ */
 export async function loadOBF(file: File): Promise<OBFBoard> {
   const json = await file.text();
   return parseOBF(json);
 }
 
+/**
+ * Validate an unknown value against the OBF board schema.
+ *
+ * @throws {Error} If the value does not conform to the schema.
+ */
 export function validateOBF(data: unknown): OBFBoard {
   const result = OBFBoardSchema.safeParse(data);
 
@@ -35,6 +62,9 @@ export function validateOBF(data: unknown): OBFBoard {
   return result.data;
 }
 
+/**
+ * Serialize an OBF board to a pretty-printed JSON string.
+ */
 export function stringifyOBF(board: OBFBoard): string {
   return JSON.stringify(board, null, 2);
 }

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -80,7 +80,10 @@ export async function createOBZ(
 
   const encoder = new TextEncoder();
 
-  entries.set("manifest.json", encoder.encode(JSON.stringify(manifest, null, 2)));
+  entries.set(
+    "manifest.json",
+    encoder.encode(JSON.stringify(manifest, null, 2)),
+  );
 
   for (const board of boards) {
     const path = `boards/${board.id}.obf`;
@@ -122,7 +125,9 @@ function extractBoards(
     const boardBytes = entries.get(path);
 
     if (!boardBytes) {
-      throw new Error(`Board "${id}" declared in manifest but missing at path "${path}"`);
+      throw new Error(
+        `Board "${id}" declared in manifest but missing at path "${path}"`,
+      );
     }
 
     const boardJson = new TextDecoder().decode(boardBytes);

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -6,63 +6,49 @@ import { isZip, unzip, zip } from "./zip";
 export interface ParsedOBZ {
   manifest: OBFManifest;
   boards: Map<string, OBFBoard>;
-  files: Map<string, Uint8Array>;
+  resources: Map<string, Uint8Array>;
 }
 
 /**
- * Load OBZ package from File
- * @param file - File object
- * @returns Parsed OBZ with manifest, boards, and files
+ * Load an OBZ archive from a user-selected file.
  */
 export async function loadOBZ(file: File): Promise<ParsedOBZ> {
-  const buffer = await file.arrayBuffer();
-  return extractOBZ(buffer);
+  const archive = await file.arrayBuffer();
+  return extractOBZ(archive);
 }
 
 /**
- * Extract OBZ package from ArrayBuffer
- * @param buffer - OBZ file as ArrayBuffer
- * @returns Parsed OBZ with manifest, boards, and files
+ * Extract boards and resources from a raw OBZ archive.
  */
-export async function extractOBZ(buffer: ArrayBuffer): Promise<ParsedOBZ> {
-  if (!isZip(buffer)) {
+export async function extractOBZ(archive: ArrayBuffer): Promise<ParsedOBZ> {
+  if (!isZip(archive)) {
     throw new Error("Invalid OBZ: not a ZIP file");
   }
 
-  const files = await unzip(buffer);
+  const entries = await unzip(archive);
 
-  const manifestBuffer = files.get("manifest.json");
-  if (!manifestBuffer) {
-    throw new Error("Invalid OBZ: missing manifest.json");
-  }
+  const manifest = extractManifest(entries);
+  const boards = extractBoards(manifest, entries);
 
-  const manifestText = new TextDecoder().decode(manifestBuffer);
-  const manifest = parseManifest(manifestText);
-
-  const boards = new Map<string, OBFBoard>();
-  for (const [id, path] of Object.entries(manifest.paths.boards)) {
-    const boardBuffer = files.get(path);
-    if (!boardBuffer) {
-      console.warn(`Board ${id} not found at ${path}`);
-      continue;
-    }
-
-    const boardText = new TextDecoder().decode(boardBuffer);
-    const board = parseOBF(boardText);
-
-    boards.set(id, board);
-  }
-
-  return { manifest, boards, files };
+  return { manifest, boards, resources: entries };
 }
 
 /**
- * Parse manifest.json from OBZ package
- * @param json - Manifest JSON string
- * @returns Validated Manifest object
+ * Parse and validate a manifest JSON string.
  */
 export function parseManifest(json: string): OBFManifest {
-  const data = JSON.parse(json) as unknown;
+  let data: unknown;
+
+  try {
+    data = JSON.parse(json) as unknown;
+  } catch (error) {
+    throw new Error(
+      `Invalid manifest: JSON parse failed${
+        (error as Error)?.message ? ` — ${(error as Error).message}` : ""
+      }`,
+    );
+  }
+
   const result = OBFManifestSchema.safeParse(data);
 
   if (!result.success) {
@@ -73,51 +59,75 @@ export function parseManifest(json: string): OBFManifest {
 }
 
 /**
- * Create OBZ package from boards and resources
- * @param boards - Array of Board objects
- * @param rootBoardId - ID of the root board
- * @param resources - Optional map of resource paths to buffers
- * @returns OBZ package as Blob
+ * Bundle boards and optional resources into a downloadable OBZ archive.
  */
 export async function createOBZ(
   boards: OBFBoard[],
   rootBoardId: string,
   resources?: Map<string, Uint8Array | ArrayBuffer>,
 ): Promise<Blob> {
-  const files = new Map<string, Uint8Array | ArrayBuffer>();
+  const entries = new Map<string, Uint8Array | ArrayBuffer>();
 
-  // Create and validate manifest
+  const boardPaths = Object.fromEntries(
+    boards.map((board) => [board.id, `boards/${board.id}.obf`]),
+  );
+
   const manifest = OBFManifestSchema.parse({
     format: "open-board-0.1",
     root: `boards/${rootBoardId}.obf`,
-    paths: {
-      boards: Object.fromEntries(
-        boards.map((board) => [board.id, `boards/${board.id}.obf`]),
-      ),
-      images: {},
-      sounds: {},
-    },
+    paths: { boards: boardPaths, images: {}, sounds: {} },
   });
 
-  // Add manifest.json
-  const manifestJSON = JSON.stringify(manifest, null, 2);
-  files.set("manifest.json", new TextEncoder().encode(manifestJSON).buffer);
+  const encoder = new TextEncoder();
 
-  // Add board files
+  entries.set("manifest.json", encoder.encode(JSON.stringify(manifest, null, 2)));
+
   for (const board of boards) {
-    const boardJSON = JSON.stringify(board, null, 2);
     const path = `boards/${board.id}.obf`;
-    files.set(path, new TextEncoder().encode(boardJSON).buffer);
+    entries.set(path, encoder.encode(JSON.stringify(board, null, 2)));
   }
 
-  // Add resource files
   if (resources) {
-    for (const [path, buffer] of resources.entries()) {
-      files.set(path, buffer);
+    for (const [path, bytes] of resources) {
+      entries.set(path, bytes);
     }
   }
 
-  // Create ZIP
-  const zipBuffer = await zip(files);
-  return new Blob([new Uint8Array(zipBuffer)], { type: "application/zip" });
+  const compressed = await zip(entries);
+  return new Blob([new Uint8Array(compressed)], { type: "application/zip" });
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function extractManifest(entries: Map<string, Uint8Array>): OBFManifest {
+  const manifestBytes = entries.get("manifest.json");
+
+  if (!manifestBytes) {
+    throw new Error("Invalid OBZ: missing manifest.json");
+  }
+
+  const manifestJson = new TextDecoder().decode(manifestBytes);
+  return parseManifest(manifestJson);
+}
+
+function extractBoards(
+  manifest: OBFManifest,
+  entries: Map<string, Uint8Array>,
+): Map<string, OBFBoard> {
+  const boards = new Map<string, OBFBoard>();
+
+  for (const [id, path] of Object.entries(manifest.paths.boards)) {
+    const boardBytes = entries.get(path);
+
+    if (!boardBytes) {
+      throw new Error(`Board "${id}" declared in manifest but missing at path "${path}"`);
+    }
+
+    const boardJson = new TextDecoder().decode(boardBytes);
+    boards.set(id, parseOBF(boardJson));
+  }
+
+  return boards;
 }

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -17,9 +17,7 @@ const COMPRESSION_LEVEL = 6;
  *
  * @param archive - The raw ZIP bytes to decompress.
  */
-export function unzip(
-  archive: ArrayBuffer,
-): Promise<Map<string, Uint8Array>> {
+export function unzip(archive: ArrayBuffer): Promise<Map<string, Uint8Array>> {
   return new Promise((resolve, reject) => {
     const compressed = new Uint8Array(archive);
 

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -1,37 +1,62 @@
 import { unzip as fflateUnzip, zip as fflateZip } from "fflate";
 
-export function unzip(buffer: ArrayBuffer): Promise<Map<string, Uint8Array>> {
-  return new Promise((resolve, reject) => {
-    const input = new Uint8Array(buffer);
+/**
+ * First two bytes of every ZIP archive — the ASCII letters `PK`,
+ * after Phil Katz, creator of the format.
+ *
+ * Only the 2-byte prefix is checked intentionally: this keeps the
+ * test lightweight and sufficient for distinguishing ZIP from JSON.
+ */
+const ZIP_MAGIC = [0x50, 0x4b] as const;
 
-    fflateUnzip(input, (error, result) => {
+/** Balanced speed-vs-size deflate level used by fflate (1–9 scale). */
+const COMPRESSION_LEVEL = 6;
+
+/**
+ * Decompress a ZIP archive into a map of file paths to raw bytes.
+ *
+ * @param archive - The raw ZIP bytes to decompress.
+ */
+export function unzip(
+  archive: ArrayBuffer,
+): Promise<Map<string, Uint8Array>> {
+  return new Promise((resolve, reject) => {
+    const compressed = new Uint8Array(archive);
+
+    fflateUnzip(compressed, (error, entries) => {
       if (error) {
         reject(new Error(`Failed to unzip: ${error.message ?? String(error)}`));
         return;
       }
 
-      const files = new Map<string, Uint8Array>();
-      for (const [path, bytes] of Object.entries(result)) {
-        files.set(path, bytes);
-      }
+      const pathToBytes = new Map<string, Uint8Array>(Object.entries(entries));
 
-      resolve(files);
+      resolve(pathToBytes);
     });
   });
 }
 
+/**
+ * Compress a map of file paths and contents into a single ZIP archive.
+ *
+ * Accepts both `Uint8Array` and `ArrayBuffer` values so callers can
+ * pass the output of `unzip` directly or supply raw `ArrayBuffer`s
+ * without converting first.
+ *
+ * @param entries - A map of file paths to their content bytes.
+ */
 export function zip(
-  files: Map<string, Uint8Array | ArrayBuffer>,
+  entries: Map<string, Uint8Array | ArrayBuffer>,
 ): Promise<Uint8Array> {
   return new Promise((resolve, reject) => {
-    const input: Record<string, Uint8Array> = {};
+    const pathToBytes: Record<string, Uint8Array> = {};
 
-    for (const [path, content] of files) {
-      input[path] =
+    for (const [path, content] of entries) {
+      pathToBytes[path] =
         content instanceof Uint8Array ? content : new Uint8Array(content);
     }
 
-    fflateZip(input, { level: 6 }, (error, result) => {
+    fflateZip(pathToBytes, { level: COMPRESSION_LEVEL }, (error, result) => {
       if (error) {
         reject(new Error(`Failed to zip: ${error.message ?? String(error)}`));
         return;
@@ -42,7 +67,15 @@ export function zip(
   });
 }
 
-export function isZip(buffer: ArrayBuffer): boolean {
-  const view = new Uint8Array(buffer);
-  return view.length >= 2 && view[0] === 0x50 && view[1] === 0x4b;
+/**
+ * Test whether an `ArrayBuffer` begins with the 2-byte ZIP
+ * magic prefix (`PK`).
+ */
+export function isZip(archive: ArrayBuffer): boolean {
+  const bytes = new Uint8Array(archive);
+
+  return (
+    bytes.length >= ZIP_MAGIC.length &&
+    ZIP_MAGIC.every((byte, index) => bytes[index] === byte)
+  );
 }

--- a/tests/obz.test.ts
+++ b/tests/obz.test.ts
@@ -42,8 +42,8 @@ describe("extractOBZ", () => {
     const result = await extractOBZ(await obzBlob.arrayBuffer());
 
     expect(result.manifest.root).toBe("boards/test.obf");
-    expect(result.files.has("manifest.json")).toBe(true);
-    expect(result.files.has("boards/test.obf")).toBe(true);
+    expect(result.resources.has("manifest.json")).toBe(true);
+    expect(result.resources.has("boards/test.obf")).toBe(true);
 
     const extractedBoard = result.boards.get("test");
     expect(extractedBoard).toMatchObject({
@@ -72,7 +72,7 @@ describe("extractOBZ", () => {
     );
   });
 
-  test("handles manifest referencing missing board file", async () => {
+  test("throws when manifest references a missing board file", async () => {
     const manifest = JSON.stringify({
       format: "open-board-0.1",
       root: "boards/missing.obf",
@@ -83,10 +83,9 @@ describe("extractOBZ", () => {
     ]);
     const zipBuffer = await zip(filesWithMissingBoard);
 
-    const result = await extractOBZ(zipBuffer.buffer as ArrayBuffer);
-
-    expect(result.boards.size).toBe(0);
-    expect(result.boards.has("missing")).toBe(false);
+    await expect(
+      extractOBZ(zipBuffer.buffer as ArrayBuffer),
+    ).rejects.toThrow('Board "missing" declared in manifest but missing');
   });
 });
 
@@ -123,7 +122,7 @@ describe("createOBZ", () => {
     const obzBlob = await createOBZ([board], "board-1", resources);
     const extracted = await extractOBZ(await obzBlob.arrayBuffer());
 
-    expect(extracted.files.get("images/test.png")).toEqual(imageData);
+    expect(extracted.resources.get("images/test.png")).toEqual(imageData);
   });
 });
 


### PR DESCRIPTION
Every change in this branch was guided by the [Poet Agent](.github/agents/poet.agent.md) — a set of literary standards for treating code as a manuscript. This PR is a concrete demonstration of those principles applied to the three core modules: `zip.ts`, `obf.ts`, and `obz.ts`.

No features were added. No bugs were fixed. This is purely a *readability* refactor — and the reasoning behind every edit is documented below.

---

## 1. The Vocabulary Edit — Naming & Clarity

> *"Eradicate weasel words. Names must be exact and unambiguous."*

| Before | After | Reason |
|---|---|---|
| `buffer` | `archive` | `buffer` describes the container type, not the content. The parameter holds a ZIP *archive*. |
| `input` | `compressed` | Inside `unzip`, the bytes are compressed data. Saying what they *are* beats saying where they *came from*. |
| `result` (unzip callback) | `entries` | The decompression result is a set of *entries*, not a generic "result." |
| `files` (`ParsedOBZ`) | `resources` | The map holds images, sounds, and boards — domain assets. "Files" is a filesystem concept that leaks implementation into the interface. |
| `data` (`parseOBF`) | `rawBoard` | `data` is the single most overloaded word in programming. `rawBoard` says exactly what it is: an unvalidated board. |
| `input` (zip) | `pathToBytes` | A record keyed by path whose values are byte arrays. The name *is* the type documentation. |
| `trimmed` | `sanitized` | The BOM strip is a sanitization step, not a whitespace trim. |
| `manifestBuffer` / `boardBuffer` | `manifestBytes` / `boardBytes` | "Buffer" is an API type (`ArrayBuffer`). These are already `Uint8Array` — raw *bytes*. |
| `manifestText` / `boardText` | `manifestJson` / `boardJson` | The decoded strings are JSON, not arbitrary text. |

## 2. The Fluency Edit — Simplicity & Flow

> *"Good prose omits needless words; good code omits needless logic."*

**Inline logic → named helpers (`obf.ts`).** The BOM check and error-message construction were inlined inside `parseOBF`, forcing the reader to parse two concerns at once. Extracted to `stripBom` and `buildParseErrorMessage` so the main function reads as a three-step narrative: sanitize → parse → validate.

**Manual loop → constructor (`zip.ts`).** The `unzip` callback built a `Map` by iterating `Object.entries(result)` and calling `.set()` on each pair. Replaced with `new Map(Object.entries(entries))` — one expression that says the same thing without ceremony.

**Repeated `new TextEncoder()` → shared instance (`obz.ts`).** `createOBZ` allocated a fresh encoder on every `.set()` call. Hoisted to a single `const encoder` — fewer allocations, and the reader sees the tool once, then watches it used.

**Nested manifest construction → hoisted binding (`obz.ts`).** The `boardPaths` mapping was buried three levels deep inside the manifest literal. Lifted into its own `const boardPaths` so the manifest reads as a flat data declaration.

## 3. The Iceberg Rule — Structural Abstraction  

> *"Bury the 90% inside cleanly named helpers, leaving only the 10% visible."*

The original `extractOBZ` was a 25-line function that validated ZIP magic, decompressed, located the manifest, decoded it, parsed it, then looped over boards with inline error handling. After the refactor, it reads:

```ts
const entries   = await unzip(archive);
const manifest  = extractManifest(entries);
const boards    = extractBoards(manifest, entries);
return { manifest, boards, resources: entries };
```

The implementation details now live in two focused helpers (`extractManifest`, `extractBoards`) below the public API, separated by a visual divider comment. The main function is a four-line narrative.

## 4. The Turn — Error Handling

> *"Treat errors as dramatic shifts. They must not interrupt the narrative flow."*

**Silent warning → loud throw (`obz.ts`).** When a board declared in `manifest.json` was missing from the archive, the old code called `console.warn` and moved on — silently returning incomplete data. This is the code equivalent of a footnote that says "chapter 3 might be missing." The refactor throws a descriptive `Error` with both the board ID and expected path, because corrupt data should halt the program, not quietly degrade it.

**Unguarded `JSON.parse` → try/catch (`obz.ts`).** `parseManifest` previously let `JSON.parse` throw a raw `SyntaxError`. Now it catches and wraps the error with `"Invalid manifest: JSON parse failed"` — consistent with the pattern already established in `parseOBF`.

## 5. The Prose Edit — Commentary

> *"Delete the 'what.' Elevate the 'why.'"*

**Deleted:** Comments like `// Create and validate manifest`, `// Add manifest.json`, `// Add board files`, `// Add resource files`, `// Create ZIP`. Each one repeated the line of code that followed it.

**Deleted:** JSDoc tags that restated type signatures — `@param file - File object`, `@returns Parsed OBZ with manifest, boards, and files`. The types already say this.

**Added:** JSDoc on every public function explaining *intent and context* — when to use `loadOBF` vs `parseOBF`, *why* `zip` accepts both `Uint8Array` and `ArrayBuffer`, *why* only 2 bytes are checked in `isZip`.

**Added:** Named constants `ZIP_MAGIC` and `COMPRESSION_LEVEL` with doc comments explaining the historical origin of the `PK` signature and the choice of deflate level 6.

## 6. The Visual Edit — Paragraphs of Logic

> *"A wall of text is exhausting."*

Inserted vertical whitespace to separate logical paragraphs: guard clause → decompression → manifest extraction → board extraction → return. Each "paragraph" in a function is now visually distinct.

## Breaking changes

- `ParsedOBZ.files` → `ParsedOBZ.resources` (rename only — same type, same content).
- Missing board files now throw instead of `console.warn` and continue. This is intentionally stricter.

## Tooling

Added `.github/agents/poet.agent.md` — the Copilot agent prompt that codifies the review philosophy behind these changes, so future refactors follow the same editorial standards.
