### PR TITLE
chore: include CHANGELOG.md in published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "types": "./dist/index.d.mts",
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "tsdown",


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` to `files` so the changesets-generated changelog gets published. npm auto-includes README and LICENSE but **not** CHANGELOG, so without this the first release would ship without release notes.

## Test plan
- [x] `npm run pack:check` (publint --strict) clean
- [ ] CI green