### PR TITLE
chore(release): wire NPM_TOKEN into publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,5 @@ jobs:
           publish: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
Pass NPM_TOKEN as NODE_AUTH_TOKEN to changesets/action so npm publish authenticates.