### PR TITLE
chore(deps): bump fflate to ^0.8.3 and vitest to ^4.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@shayc/open-board-format",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shayc/open-board-format",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "fflate": "^0.8.2",
+        "fflate": "^0.8.3",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -24,7 +24,7 @@
         "tsdown": "^0.22.0",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.60.0",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.7"
       },
       "engines": {
         "node": ">=24"

--- a/package.json
+++ b/package.json
@@ -53,10 +53,10 @@
     "tsdown": "^0.22.0",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.60.0",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.7"
   },
   "dependencies": {
-    "fflate": "^0.8.2",
+    "fflate": "^0.8.3",
     "zod": "^4.4.3"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary
- \`fflate: ^0.8.2 → ^0.8.3\` (runtime dep, patch)
- \`vitest: ^4.1.6 → ^4.1.7\` (devDep, patch)

\`fflate\` is a runtime dep, so the bump will ship to consumers via the OBZ ZIP path. If you want this released as 0.1.2, add a changeset (\`npx changeset\`, patch). Without one, the bump just sits on main until something else triggers a release.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npx prettier --check .\` clean
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 101/101 passing
- [x] \`npm run build\` clean
- [x] \`npm run pack:check\` (publint --strict) clean
- [ ] CI green