### PR TITLE
chore: test against Node 22 and 24 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["22", "24"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: ${{ matrix.node }}
           cache: "npm"
       - run: npm ci
       - run: npm run lint


### PR DESCRIPTION
## Summary
- Add a CI build matrix (`fail-fast: false`, `node: ["22", "24"]`) so tests run on both supported LTS lines.
- Validates the `engines.node: ">=22"` floor (landed in #17) in addition to active LTS (24), instead of only testing the newest version.

## Test plan
- [ ] CI runs the full lint/typecheck/test/build job twice — once on Node 22, once on Node 24 — and both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)