### PR TITLE
fix: validate boards in createOBZ and tidy schemas/docs

### DIFF
--- a/.changeset/validate-boards-and-schema-cleanup.md
+++ b/.changeset/validate-boards-and-schema-cleanup.md
@@ -1,0 +1,7 @@
+---
+"@shayc/open-board-format": patch
+---
+
+- `createOBZ` now validates each board against `OBFBoardSchema` before writing it into the archive, so invalid input fails loudly instead of producing a structurally broken `.obf` (closes #13).
+- `OBFImageSchema` is built with `.extend()` instead of `.and()`, so it is a regular object schema again (supports `.extend()`/`.pick()`/`.shape`); parsing behavior, including `ext_` passthrough, is unchanged.
+- Corrected misleading JSDoc on `ParsedOBZ.resources` (it holds every archive entry, not only media) and on `OBFLocaleCodeSchema` (a plain string, not strictly BCP 47 validated; closes #14).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing to `@shayc/open-board-format`.
 
 ## Development
 
-Requires Node 24+.
+Requires Node 22+.
 
 ```bash
 npm install
@@ -14,7 +14,7 @@ Common commands:
 
 ```bash
 npm run lint        # eslint
-npm run typecheck   # tsc --noEmit
+npm run typecheck   # type-check only (noEmit via tsconfig)
 npm test            # vitest run
 npm run build       # tsdown → dist/
 ```

--- a/src/obf.ts
+++ b/src/obf.ts
@@ -8,12 +8,15 @@ function stripBom(text: string): string {
   return text.startsWith(UTF8_BOM) ? text.slice(1) : text;
 }
 
-/** Build a descriptive parse-failure message, preserving the engine's reason when available. */
-function buildParseErrorMessage(error: unknown): string {
+/** Build a descriptive JSON parse-failure message, preserving the engine's reason when available. */
+export function buildJsonParseErrorMessage(
+  label: string,
+  error: unknown,
+): string {
   const reason = error instanceof Error ? error.message : "";
   return reason
-    ? `Invalid OBF: JSON parse failed — ${reason}`
-    : "Invalid OBF: JSON parse failed";
+    ? `Invalid ${label}: JSON parse failed — ${reason}`
+    : `Invalid ${label}: JSON parse failed`;
 }
 
 /**
@@ -35,7 +38,7 @@ export function parseOBF(json: string): OBFBoard {
   try {
     rawBoard = JSON.parse(sanitized) as unknown;
   } catch (error) {
-    throw new Error(buildParseErrorMessage(error), { cause: error });
+    throw new Error(buildJsonParseErrorMessage("OBF", error), { cause: error });
   }
 
   return validateOBF(rawBoard);

--- a/src/obz.test.ts
+++ b/src/obz.test.ts
@@ -138,6 +138,19 @@ describe("createOBZ", () => {
     );
   });
 
+  test("throws when a supplied board fails schema validation", async () => {
+    const invalidBoard = {
+      format: "open-board-0.1",
+      id: "bad",
+      buttons: [],
+      // grid is required by OBFBoardSchema
+    } as unknown as OBFBoard;
+
+    await expect(createOBZ([invalidBoard], "bad")).rejects.toThrow(
+      /Invalid OBZ: board "bad" failed validation/,
+    );
+  });
+
   test("populates manifest.paths.images from board image entries", async () => {
     const board: OBFBoard = {
       format: "open-board-0.1",

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -1,6 +1,6 @@
-import { parseOBF } from "./obf";
+import { buildJsonParseErrorMessage, parseOBF } from "./obf";
 import type { OBFBoard, OBFManifest } from "./schema";
-import { OBFManifestSchema } from "./schema";
+import { OBFBoardSchema, OBFManifestSchema } from "./schema";
 import { isZip, unzip, zip } from "./zip";
 
 /**
@@ -8,7 +8,9 @@ import { isZip, unzip, zip } from "./zip";
  *
  * @property manifest  - The package table of contents.
  * @property boards    - Board ID → validated board object.
- * @property resources - Archive path → raw binary content (images, sounds, etc.).
+ * @property resources - Archive path → raw bytes for every entry in the archive,
+ *                       including `manifest.json` and the `.obf` boards as well as
+ *                       media such as images and sounds.
  */
 export interface ParsedOBZ {
   manifest: OBFManifest;
@@ -69,12 +71,9 @@ export function parseManifest(json: string): OBFManifest {
   try {
     data = JSON.parse(json) as unknown;
   } catch (error) {
-    throw new Error(
-      `Invalid manifest: JSON parse failed${
-        (error as Error)?.message ? ` — ${(error as Error).message}` : ""
-      }`,
-      { cause: error },
-    );
+    throw new Error(buildJsonParseErrorMessage("manifest", error), {
+      cause: error,
+    });
   }
 
   const result = OBFManifestSchema.safeParse(data);
@@ -119,7 +118,7 @@ export async function createOBZ(
   const imagePaths = collectMediaPaths(boards, "images");
   const soundPaths = collectMediaPaths(boards, "sounds");
 
-  const manifest = OBFManifestSchema.parse({
+  const manifestResult = OBFManifestSchema.safeParse({
     format: "open-board-0.1",
     root: `boards/${rootBoardId}.obf`,
     paths: {
@@ -129,6 +128,14 @@ export async function createOBZ(
     },
   });
 
+  if (!manifestResult.success) {
+    throw new Error(
+      `Invalid OBZ: generated manifest failed validation — ${manifestResult.error.message}`,
+    );
+  }
+
+  const manifest = manifestResult.data;
+
   const encoder = new TextEncoder();
 
   entries.set(
@@ -137,8 +144,14 @@ export async function createOBZ(
   );
 
   for (const board of boards) {
-    const path = `boards/${board.id}.obf`;
-    entries.set(path, encoder.encode(JSON.stringify(board, null, 2)));
+    const result = OBFBoardSchema.safeParse(board);
+    if (!result.success) {
+      throw new Error(
+        `Invalid OBZ: board "${board.id}" failed validation — ${result.error.message}`,
+      );
+    }
+    const path = `boards/${result.data.id}.obf`;
+    entries.set(path, encoder.encode(JSON.stringify(result.data, null, 2)));
   }
 
   if (resources) {
@@ -148,7 +161,7 @@ export async function createOBZ(
   }
 
   const compressed = await zip(entries);
-  return new Blob([new Uint8Array(compressed)], { type: "application/zip" });
+  return new Blob([compressed], { type: "application/zip" });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -47,7 +47,8 @@ export const OBFFormatVersionSchema = z.string().regex(/^open-board-.+$/);
 export type OBFFormatVersion = z.infer<typeof OBFFormatVersionSchema>;
 
 /**
- * Locale code as per BCP 47 language tags, e.g., 'en', 'en-US', 'fr-CA'.
+ * Locale identifier, typically a BCP 47 language tag (e.g., 'en', 'en-US', 'fr-CA').
+ * Not strictly validated — any string is accepted.
  */
 export const OBFLocaleCodeSchema = z.string();
 export type OBFLocaleCode = z.infer<typeof OBFLocaleCodeSchema>;
@@ -158,16 +159,14 @@ export type OBFSymbolInfo = z.infer<typeof OBFSymbolInfoSchema>;
  * 3. `url`
  * 4. `symbol`
  */
-export const OBFImageSchema = OBFMediaSchema.and(
-  z.object({
-    /** Information about a symbol from a proprietary symbol set. */
-    symbol: OBFSymbolInfoSchema.optional(),
-    /** Width of the image in pixels. */
-    width: z.number().optional(),
-    /** Height of the image in pixels. */
-    height: z.number().optional(),
-  }),
-);
+export const OBFImageSchema = OBFMediaSchema.extend({
+  /** Information about a symbol from a proprietary symbol set. */
+  symbol: OBFSymbolInfoSchema.optional(),
+  /** Width of the image in pixels. */
+  width: z.number().optional(),
+  /** Height of the image in pixels. */
+  height: z.number().optional(),
+});
 export type OBFImage = z.infer<typeof OBFImageSchema>;
 
 /**


### PR DESCRIPTION
## Summary

Hardening and consistency pass that closes #13 and #14. No new features; low-risk.

- **`createOBZ` validates input** — each board (and the generated manifest) is validated before being written, so invalid input fails loudly with a uniform `Invalid OBZ:` prefix instead of producing a structurally broken `.obf` or throwing raw `ZodError`s. (closes #13)
- **`OBFImageSchema` uses `.extend()` instead of `.and()`** — keeps it a composable object schema (`.extend()`/`.pick()`/`.shape`) and consistent with sibling schemas; parsing behavior, including `ext_` passthrough, is unchanged.
- **JSDoc corrections** — `ParsedOBZ.resources` actually holds *every* archive entry (manifest + boards + media), and `OBFLocaleCodeSchema` is a plain string, not strictly BCP 47 validated. (closes #14)
- **Internal tidy** — share the JSON parse-error helper between `parseOBF`/`parseManifest` (drops an unsafe error cast); remove a redundant `Uint8Array` copy in `createOBZ`.
- **Docs** — correct Node version (`22+`) and the typecheck comment in CONTRIBUTING.

### Note
`createOBZ` now throws on invalid boards and serializes the normalized (Zod-parsed) board. Both are improvements but are minor behavior changes — shipped as a `patch` changeset.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (102 passing; added a test for the new validation throw path)
- [x] `npm run format:check`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)