### PR TITLE
chore: add vitest config and expose types in package exports

### DIFF
--- a/.changeset/vitest-config-types-export.md
+++ b/.changeset/vitest-config-types-export.md
@@ -1,0 +1,5 @@
+---
+"@shayc/open-board-format": patch
+---
+
+Expose a `types` condition in the package `exports` map so TypeScript consumers resolve declarations for the package entry point.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
-    ".": "./dist/index.mjs",
+    ".": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src", "tsdown.config.ts"]
+  "include": ["src", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    restoreMocks: true,
+    unstubGlobals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- Add a vitest config (`restoreMocks`, `unstubGlobals`)
- Include `vitest.config.ts` in the tsconfig project so it's type-checked
- Add an explicit `types` condition to the package `exports` map so TypeScript consumers resolve `dist/index.d.mts`
- Patch changeset for the exports fix (consumer-facing)

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm test` (102 passed)
- [x] `npm run build` (emits `dist/index.d.mts`, matching the new `types` export)

🤖 Generated with [Claude Code](https://claude.com/claude-code)