### PR TITLE
fix: prefix OBZ missing-board error with `Invalid OBZ:`

### DIFF
--- a/.changeset/obz-error-prefix.md
+++ b/.changeset/obz-error-prefix.md
@@ -1,0 +1,5 @@
+---
+"@shayc/open-board-format": patch
+---
+
+Prefix the OBZ missing-board extraction error with `Invalid OBZ:` so it matches the convention used by every other OBZ failure, letting consumers reliably detect malformed packages by message prefix.

--- a/README.md
+++ b/README.md
@@ -105,12 +105,12 @@ if (result.success) {
 
 ### OBZ (board package)
 
-| Function                                | Description                                                   |
-| --------------------------------------- | ------------------------------------------------------------- |
-| `loadOBZ(file)`                         | Load an OBZ package from a browser `File`                     |
-| `extractOBZ(archive)`                   | Extract boards, manifest, and resources from an `ArrayBuffer` |
-| `createOBZ(boards, rootId, resources?)` | Create an OBZ package as a `Blob`                             |
-| `parseManifest(json)`                   | Parse a `manifest.json` string into a validated `OBFManifest` |
+| Function                                     | Description                                                   |
+| -------------------------------------------- | ------------------------------------------------------------- |
+| `loadOBZ(file)`                              | Load an OBZ package from a browser `File`                     |
+| `extractOBZ(archive)`                        | Extract boards, manifest, and resources from an `ArrayBuffer` |
+| `createOBZ(boards, rootBoardId, resources?)` | Create an OBZ package as a `Blob`                             |
+| `parseManifest(json)`                        | Parse a `manifest.json` string into a validated `OBFManifest` |
 
 ### Utilities
 
@@ -143,6 +143,14 @@ if (result.success) {
 | `OBFLocaleCode`       | BCP 47 locale code                                                          |
 | `OBFLocalizedStrings` | Key-value string translations                                               |
 | `OBFStrings`          | Multi-locale string translations                                            |
+
+### Schemas
+
+Every type above except `ParsedOBZ` is exported alongside a matching Zod schema with a `Schema` suffix — `OBFBoard` → `OBFBoardSchema`, `OBFManifest` → `OBFManifestSchema`, and so on. Import any of them to validate with `safeParse`/`parse` or to compose into your own schemas:
+
+```ts
+import { OBFButtonSchema, OBFManifestSchema } from "@shayc/open-board-format";
+```
 
 ## Errors
 

--- a/src/obz.test.ts
+++ b/src/obz.test.ts
@@ -84,7 +84,7 @@ describe("extractOBZ", () => {
     const zipBuffer = await zip(filesWithMissingBoard);
 
     await expect(extractOBZ(zipBuffer.buffer as ArrayBuffer)).rejects.toThrow(
-      'Board "missing" declared in manifest but missing',
+      'Invalid OBZ: board "missing" declared in manifest but missing',
     );
   });
 });

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -222,7 +222,7 @@ function extractBoards(
 
     if (!boardBytes) {
       throw new Error(
-        `Board "${id}" declared in manifest but missing at path "${path}"`,
+        `Invalid OBZ: board "${id}" declared in manifest but missing at path "${path}"`,
       );
     }
 


### PR DESCRIPTION
## Summary
- Prefix the OBZ missing-board extraction error with `Invalid OBZ:` so it matches the convention shared by every other OBZ failure (`extractBoards` was the only outlier). Consumers can now reliably detect malformed packages by message prefix, as documented in the README's Errors section.
- README: correct the `createOBZ` param name (`rootId` → `rootBoardId`) to match the source signature.
- README: add a **Schemas** section documenting the `*Schema` Zod exports, closing a gap in the API reference.

Includes a patch changeset.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm test` (102 passing; updated the assertion for the new error prefix)
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)