### PR TITLE
fix: enforce archive integrity in createOBZ

### DIFF
--- a/.changeset/obz-create-integrity-checks.md
+++ b/.changeset/obz-create-integrity-checks.md
@@ -1,0 +1,5 @@
+---
+"@shayc/open-board-format": patch
+---
+
+`createOBZ` now guarantees the archive it produces is internally consistent: it throws if a board declares an image or sound `path` with no matching entry in `resources`, and throws if a `resources` entry would overwrite the generated `manifest.json` or a board file. This mirrors the missing-board check `extractOBZ` already performs, so a package that round-trips through `createOBZ` → `extractOBZ` can no longer reference files that aren't in the archive. Use the lower-level `zip()` primitive if you need to assemble an archive without these guarantees.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ import { OBFButtonSchema, OBFManifestSchema } from "@shayc/open-board-format";
 All failures throw plain `Error`. The message identifies what failed, typically with one of these prefixes:
 
 - `Invalid OBF:` — schema validation rejected an OBF board.
-- `Invalid OBZ:` — the package was malformed (not a ZIP, missing manifest, unreadable entry).
+- `Invalid OBZ:` — the package was rejected. On read: not a ZIP, missing manifest, or the manifest references a board file not in the archive. On write (`createOBZ`): `rootBoardId` matches no board, a board fails validation, two boards map the same media id to conflicting paths, a declared image/sound `path` has no matching resource, or a resource would overwrite a generated entry.
 - `Invalid manifest:` — `manifest.json` failed to parse or validate.
 
 When the root cause is a `JSON.parse` failure, the original error is preserved as `error.cause`. For finer-grained validation, drop one level down and use the Zod schemas directly with `safeParse` — the `issues` array tells you exactly which field failed.

--- a/src/obz.test.ts
+++ b/src/obz.test.ts
@@ -159,9 +159,10 @@ describe("createOBZ", () => {
       grid: { rows: 1, columns: 1, order: [["btn"]] },
       images: [{ id: "i1", path: "images/i1.png" }],
     };
+    const resources = new Map([["images/i1.png", new Uint8Array([1])]]);
 
     const extracted = await extractOBZ(
-      await (await createOBZ([board], "b")).arrayBuffer(),
+      await (await createOBZ([board], "b", resources)).arrayBuffer(),
     );
 
     expect(extracted.manifest.paths.images).toEqual({ i1: "images/i1.png" });
@@ -175,12 +176,69 @@ describe("createOBZ", () => {
       grid: { rows: 1, columns: 1, order: [["btn"]] },
       sounds: [{ id: "s1", path: "sounds/s1.mp3" }],
     };
+    const resources = new Map([["sounds/s1.mp3", new Uint8Array([1])]]);
 
     const extracted = await extractOBZ(
-      await (await createOBZ([board], "b")).arrayBuffer(),
+      await (await createOBZ([board], "b", resources)).arrayBuffer(),
     );
 
     expect(extracted.manifest.paths.sounds).toEqual({ s1: "sounds/s1.mp3" });
+  });
+
+  test("throws when a board image path has no matching resource", async () => {
+    const board: OBFBoard = {
+      format: "open-board-0.1",
+      id: "b",
+      buttons: [{ id: "btn", image_id: "i1" }],
+      grid: { rows: 1, columns: 1, order: [["btn"]] },
+      images: [{ id: "i1", path: "images/i1.png" }],
+    };
+
+    await expect(createOBZ([board], "b")).rejects.toThrow(
+      /image "i1" references "images\/i1\.png" but no matching resource/,
+    );
+  });
+
+  test("throws when a board sound path has no matching resource", async () => {
+    const board: OBFBoard = {
+      format: "open-board-0.1",
+      id: "b",
+      buttons: [{ id: "btn", sound_id: "s1" }],
+      grid: { rows: 1, columns: 1, order: [["btn"]] },
+      sounds: [{ id: "s1", path: "sounds/s1.mp3" }],
+    };
+
+    await expect(createOBZ([board], "b")).rejects.toThrow(
+      /sound "s1" references "sounds\/s1\.mp3" but no matching resource/,
+    );
+  });
+
+  test("throws when a resource collides with the generated manifest", async () => {
+    const board: OBFBoard = {
+      format: "open-board-0.1",
+      id: "b",
+      buttons: [],
+      grid: { rows: 1, columns: 1, order: [[null]] },
+    };
+    const resources = new Map([["manifest.json", new Uint8Array([1])]]);
+
+    await expect(createOBZ([board], "b", resources)).rejects.toThrow(
+      /resource path "manifest\.json" collides with a generated/,
+    );
+  });
+
+  test("throws when a resource collides with a generated board file", async () => {
+    const board: OBFBoard = {
+      format: "open-board-0.1",
+      id: "b",
+      buttons: [],
+      grid: { rows: 1, columns: 1, order: [[null]] },
+    };
+    const resources = new Map([["boards/b.obf", new Uint8Array([1])]]);
+
+    await expect(createOBZ([board], "b", resources)).rejects.toThrow(
+      /resource path "boards\/b\.obf" collides with a generated/,
+    );
   });
 
   test("omits sounds map when no sounds have paths", async () => {

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -97,6 +97,10 @@ export function parseManifest(json: string): OBFManifest {
  * @returns A `Blob` containing the compressed OBZ archive.
  *
  * @throws {Error} If `rootBoardId` does not match any of the supplied boards.
+ * @throws {Error} If a supplied board fails schema validation.
+ * @throws {Error} If two boards declare the same media id with conflicting paths.
+ * @throws {Error} If a board declares an image or sound `path` with no matching entry in `resources`.
+ * @throws {Error} If a `resources` entry would overwrite the generated `manifest.json` or a board file.
  */
 export async function createOBZ(
   boards: OBFBoard[],
@@ -156,9 +160,17 @@ export async function createOBZ(
 
   if (resources) {
     for (const [path, bytes] of resources) {
+      if (entries.has(path)) {
+        throw new Error(
+          `Invalid OBZ: resource path "${path}" collides with a generated board or manifest entry`,
+        );
+      }
       entries.set(path, bytes);
     }
   }
+
+  assertPathsPresent("image", imagePaths, entries);
+  assertPathsPresent("sound", soundPaths, entries);
 
   const compressed = await zip(entries);
   return new Blob([compressed], { type: "application/zip" });
@@ -198,6 +210,27 @@ function collectMediaPaths(
   }
 
   return paths;
+}
+
+/**
+ * Assert that every media path the generated manifest declares exists as an
+ * archive entry — the same contract {@link extractOBZ} assumes when reading.
+ *
+ * Only media that declared a `path` reach this check, so `url`/`data`-only
+ * media are never flagged.
+ */
+function assertPathsPresent(
+  kind: "image" | "sound",
+  paths: Record<string, string>,
+  entries: Map<string, Uint8Array | ArrayBuffer>,
+): void {
+  for (const [id, path] of Object.entries(paths)) {
+    if (!entries.has(path)) {
+      throw new Error(
+        `Invalid OBZ: ${kind} "${id}" references "${path}" but no matching resource was supplied`,
+      );
+    }
+  }
 }
 
 function extractManifest(entries: Map<string, Uint8Array>): OBFManifest {


### PR DESCRIPTION
## Summary

`createOBZ` could previously emit an internally-inconsistent archive. This adds two guards so it produces a valid OBZ or throws:

- **Missing media** — throws if a board declares an image/sound `path` with no matching entry in `resources`. Mirrors the missing-board check `extractOBZ` already performs, so a `createOBZ` → `extractOBZ` round-trip can no longer reference files absent from the archive.
- **Resource collision** — throws if a `resources` entry would overwrite the generated `manifest.json` or a board file (previously a silent last-write-wins overwrite).

Both throw the existing `Invalid OBZ:` prefix. No public API change — `createOBZ` keeps the same signature; the lower-level `zip()` primitive remains the escape hatch for assembling archives without these guarantees.

Docs updated: `createOBZ` `@throws` block and the README "Errors" section now list all failure modes.

## Test plan

- [x] 4 new tests: missing image path, missing sound path, resource colliding with manifest, resource colliding with a board file
- [x] Updated the two manifest-population tests to supply their declared resource
- [x] Full suite green: 106 tests, typecheck, lint, format:check