### PR TITLE
feat: add loadBoard format-detecting entry point

### DIFF
--- a/.changeset/add-load-board.md
+++ b/.changeset/add-load-board.md
@@ -1,0 +1,5 @@
+---
+"@shayc/open-board-format": minor
+---
+
+Add `loadBoard(file)`, a format-detecting entry point. It reads the file once, sniffs the ZIP magic prefix, and returns a discriminated union — `{ format: "obz", archive } | { format: "obf", board }`. Consumers can now accept either an `.obf` board or an `.obz` package from a single file input without inspecting the extension or re-deriving the OBF-vs-OBZ distinction themselves. Also exports the accompanying `LoadedBoard` type.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Two file types; pick the entry point by what you have:
 - **OBF** is a single board (a JSON object). Use `parseOBF` for a JSON string, `validateOBF` for an already-parsed object, `loadOBF` for a browser `File`. `stringifyOBF` serializes back out.
 - **OBZ** is a package of boards plus media (a ZIP archive). Use `loadOBZ` for a `File`, `extractOBZ` for an `ArrayBuffer`, `createOBZ` to build a new one.
 
+If you accept a `File` and don't know which of the two it is, use `loadBoard` — it sniffs the bytes and returns a `{ format, ... }` union so you don't have to inspect the extension yourself.
+
 Every OBF type ships with a matching `*Schema` Zod schema (e.g. `OBFBoardSchema`, `OBFManifestSchema`), so you can validate inline with `safeParse` or wire the schema straight into an API contract — the TypeScript types are inferred from those schemas.
 
 Validation preserves unknown fields rather than stripping them, so vendor extensions allowed by the OBF spec survive a `parseOBF` → `stringifyOBF` round trip.
@@ -78,6 +80,21 @@ const resources = new Map([["images/logo.png", pngBytes]]);
 const blob = await createOBZ(boards, "board-1", resources);
 ```
 
+### Load either format from one input
+
+```ts
+import { loadBoard } from "@shayc/open-board-format";
+
+// `file` came from a drag-and-drop or <input type="file"> — could be .obf or .obz
+const loaded = await loadBoard(file);
+
+if (loaded.format === "obz") {
+  const homeBoard = loaded.archive.boards.get("1");
+} else {
+  const board = loaded.board;
+}
+```
+
 ### Validate with Zod directly
 
 ```ts
@@ -112,6 +129,12 @@ if (result.success) {
 | `createOBZ(boards, rootBoardId, resources?)` | Create an OBZ package as a `Blob`                             |
 | `parseManifest(json)`                        | Parse a `manifest.json` string into a validated `OBFManifest` |
 
+### Either format
+
+| Function          | Description                                                                |
+| ----------------- | -------------------------------------------------------------------------- |
+| `loadBoard(file)` | Detect OBF vs OBZ from a `File` and load it; returns a `LoadedBoard` union |
+
 ### Utilities
 
 | Function         | Description                                              |
@@ -122,31 +145,32 @@ if (result.success) {
 
 ### Types
 
-| Type                  | Description                                                                 |
-| --------------------- | --------------------------------------------------------------------------- |
-| `OBFBoard`            | A single communication board                                                |
-| `OBFGrid`             | Grid layout (rows, columns, order)                                          |
-| `OBFButton`           | A button on the board                                                       |
-| `OBFButtonAction`     | Button action (spelling or specialty)                                       |
-| `OBFSpellingAction`   | Spelling action (e.g., `+s`)                                                |
-| `OBFSpecialtyAction`  | Specialty action (e.g., `:clear`)                                           |
-| `OBFLoadBoard`        | Reference to load another board                                             |
-| `OBFMedia`            | Common media properties (base for `OBFImage` and `OBFSound`)                |
-| `OBFImage`            | An image resource (extends `OBFMedia`)                                      |
-| `OBFSound`            | A sound resource (extends `OBFMedia`)                                       |
-| `OBFSymbolInfo`       | Symbol set reference                                                        |
-| `OBFManifest`         | OBZ package manifest                                                        |
-| `ParsedOBZ`           | Return type of `extractOBZ` / `loadOBZ` — `{ manifest, boards, resources }` |
-| `OBFID`               | Unique identifier (string, coerced from number)                             |
-| `OBFFormatVersion`    | Format version string (e.g., `open-board-0.1`)                              |
-| `OBFLicense`          | Licensing information                                                       |
-| `OBFLocaleCode`       | BCP 47 locale code                                                          |
-| `OBFLocalizedStrings` | Key-value string translations                                               |
-| `OBFStrings`          | Multi-locale string translations                                            |
+| Type                  | Description                                                                           |
+| --------------------- | ------------------------------------------------------------------------------------- |
+| `OBFBoard`            | A single communication board                                                          |
+| `OBFGrid`             | Grid layout (rows, columns, order)                                                    |
+| `OBFButton`           | A button on the board                                                                 |
+| `OBFButtonAction`     | Button action (spelling or specialty)                                                 |
+| `OBFSpellingAction`   | Spelling action (e.g., `+s`)                                                          |
+| `OBFSpecialtyAction`  | Specialty action (e.g., `:clear`)                                                     |
+| `OBFLoadBoard`        | Reference to load another board                                                       |
+| `OBFMedia`            | Common media properties (base for `OBFImage` and `OBFSound`)                          |
+| `OBFImage`            | An image resource (extends `OBFMedia`)                                                |
+| `OBFSound`            | A sound resource (extends `OBFMedia`)                                                 |
+| `OBFSymbolInfo`       | Symbol set reference                                                                  |
+| `OBFManifest`         | OBZ package manifest                                                                  |
+| `ParsedOBZ`           | Return type of `extractOBZ` / `loadOBZ` — `{ manifest, boards, resources }`           |
+| `LoadedBoard`         | Return type of `loadBoard` — `{ format: "obz", archive } \| { format: "obf", board }` |
+| `OBFID`               | Unique identifier (string, coerced from number)                                       |
+| `OBFFormatVersion`    | Format version string (e.g., `open-board-0.1`)                                        |
+| `OBFLicense`          | Licensing information                                                                 |
+| `OBFLocaleCode`       | BCP 47 locale code                                                                    |
+| `OBFLocalizedStrings` | Key-value string translations                                                         |
+| `OBFStrings`          | Multi-locale string translations                                                      |
 
 ### Schemas
 
-Every type above except `ParsedOBZ` is exported alongside a matching Zod schema with a `Schema` suffix — `OBFBoard` → `OBFBoardSchema`, `OBFManifest` → `OBFManifestSchema`, and so on. Import any of them to validate with `safeParse`/`parse` or to compose into your own schemas:
+Every type above except `ParsedOBZ` and `LoadedBoard` is exported alongside a matching Zod schema with a `Schema` suffix — `OBFBoard` → `OBFBoardSchema`, `OBFManifest` → `OBFManifestSchema`, and so on. Import any of them to validate with `safeParse`/`parse` or to compose into your own schemas:
 
 ```ts
 import { OBFButtonSchema, OBFManifestSchema } from "@shayc/open-board-format";

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,4 +46,8 @@ export { createOBZ, extractOBZ, loadOBZ, parseManifest } from "./obz";
 
 export type { ParsedOBZ } from "./obz";
 
+export { loadBoard } from "./load-board";
+
+export type { LoadedBoard } from "./load-board";
+
 export { isZip, unzip, zip } from "./zip";

--- a/src/load-board.test.ts
+++ b/src/load-board.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test, vi } from "vitest";
+import { loadBoard } from "./load-board";
+import { createOBZ } from "./obz";
+import type { OBFBoard } from "./schema";
+import { zip } from "./zip";
+
+const validBoard: OBFBoard = {
+  format: "open-board-0.1",
+  id: "test-board",
+  buttons: [{ id: "btn-1", label: "Hello" }],
+  grid: { rows: 1, columns: 1, order: [["btn-1"]] },
+};
+
+describe("loadBoard", () => {
+  test("loads a single OBF board from a File", async () => {
+    const file = new File([JSON.stringify(validBoard)], "test.obf");
+
+    const loaded = await loadBoard(file);
+
+    expect(loaded).toEqual({ format: "obf", board: validBoard });
+  });
+
+  test("loads an OBZ package from a File", async () => {
+    const obzBlob = await createOBZ([validBoard], "test-board");
+    const file = new File([obzBlob], "test.obz");
+
+    const loaded = await loadBoard(file);
+
+    expect(loaded.format).toBe("obz");
+    if (loaded.format !== "obz") {
+      throw new Error("expected obz");
+    }
+    expect(loaded.archive.manifest.root).toBe("boards/test-board.obf");
+    expect(loaded.archive.boards.get("test-board")).toEqual(validBoard);
+  });
+
+  test("detects format by content, not by file extension", async () => {
+    const obzBlob = await createOBZ([validBoard], "test-board");
+    // OBZ bytes behind a misleading `.obf` name — sniffing wins over the name.
+    const file = new File([obzBlob], "actually-a-package.obf");
+
+    const loaded = await loadBoard(file);
+
+    expect(loaded.format).toBe("obz");
+  });
+
+  test("reads the file exactly once", async () => {
+    const file = new File([JSON.stringify(validBoard)], "test.obf");
+    const arrayBuffer = vi.spyOn(file, "arrayBuffer");
+
+    await loadBoard(file);
+
+    // The whole point of the API: sniff and parse from a single read,
+    // never sniff-then-re-read.
+    expect(arrayBuffer).toHaveBeenCalledTimes(1);
+  });
+
+  test("surfaces the OBF parser's error for a non-ZIP malformed board", async () => {
+    const file = new File(['{ "format": "open-board-0.1", }'], "bad.obf");
+
+    await expect(loadBoard(file)).rejects.toThrow(/Invalid OBF/);
+  });
+
+  test("surfaces the OBZ extractor's error for a ZIP missing its manifest", async () => {
+    // A genuine ZIP (so it routes to the OBZ branch) whose entries omit
+    // manifest.json — the extractOBZ error must propagate unchanged.
+    const zipped = await zip(
+      new Map([["boards/x.obf", new TextEncoder().encode("{}")]]),
+    );
+    const file = new File([zipped], "no-manifest.obz");
+
+    await expect(loadBoard(file)).rejects.toThrow(
+      /Invalid OBZ: missing manifest\.json/,
+    );
+  });
+});

--- a/src/load-board.ts
+++ b/src/load-board.ts
@@ -1,0 +1,50 @@
+import { parseOBF } from "./obf";
+import { extractOBZ } from "./obz";
+import type { ParsedOBZ } from "./obz";
+import type { OBFBoard } from "./schema";
+import { isZip } from "./zip";
+
+/**
+ * Result of {@link loadBoard} — a discriminated union over the two file
+ * shapes the Open Board Format defines.
+ *
+ * Switch on `format` to narrow:
+ *
+ * ```ts
+ * const loaded = await loadBoard(file);
+ * if (loaded.format === "obz") {
+ *   loaded.archive.boards; // ParsedOBZ
+ * } else {
+ *   loaded.board;          // OBFBoard
+ * }
+ * ```
+ */
+export type LoadedBoard =
+  | { format: "obz"; archive: ParsedOBZ }
+  | { format: "obf"; board: OBFBoard };
+
+/**
+ * Detect whether a `File` is a single OBF board or an OBZ package and load it
+ * accordingly.
+ *
+ * The file is read once and its leading bytes are sniffed for the ZIP magic
+ * prefix: a ZIP is treated as an `.obz` package, anything else as an `.obf`
+ * board. This lets consumers accept either format from a single drag-and-drop
+ * or file picker without inspecting the file extension or re-deriving the
+ * OBF-vs-OBZ distinction themselves.
+ *
+ * @param file - A `File` handle pointing to an `.obf` or `.obz` file.
+ * @returns A discriminated union tagged by `format`.
+ *
+ * @throws {Error} If an OBZ archive is malformed or its manifest is missing,
+ *   or if an OBF board is malformed or fails schema validation.
+ */
+export async function loadBoard(file: File): Promise<LoadedBoard> {
+  const buffer = await file.arrayBuffer();
+
+  if (isZip(buffer)) {
+    return { format: "obz", archive: await extractOBZ(buffer) };
+  }
+
+  return { format: "obf", board: parseOBF(new TextDecoder().decode(buffer)) };
+}


### PR DESCRIPTION
## What

Adds `loadBoard(file)` — a single format-detecting entry point that reads a `File` once, sniffs the ZIP magic prefix, and returns a discriminated union:

```ts
type LoadedBoard =
  | { format: "obz"; archive: ParsedOBZ }
  | { format: "obf"; board: OBFBoard };
```

## Why

Today every consumer that accepts a `File` has to re-derive "zip ⇒ OBZ" themselves (extension check, or byte-sniffing + `isZip`), duplicating a format rule the library already owns in `extractOBZ`. `loadBoard` moves that decision into the lib: consumers dispatch on `.format` instead.

It also avoids a double read — the buffer is read once and handed to `extractOBZ`/`parseOBF`, rather than sniffing bytes and then re-reading the whole file in the loader.

## Notes

- Purely additive / non-breaking — existing `loadOBF`/`loadOBZ`/`parseOBF` are untouched.
- Reuses `isZip`, `extractOBZ`, `parseOBF` — no duplicated logic.
- Detection is by content, not extension (a tested case covers an OBZ behind a `.obf` name).

## Verification

`tsc`, eslint, prettier, `tsdown` build all clean. 111 tests pass (5 new for `loadBoard`).

A `minor` changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)