### PR TITLE
test: trim redundant comments in load-board tests

### DIFF
--- a/src/load-board.test.ts
+++ b/src/load-board.test.ts
@@ -36,7 +36,6 @@ describe("loadBoard", () => {
 
   test("detects format by content, not by file extension", async () => {
     const obzBlob = await createOBZ([validBoard], "test-board");
-    // OBZ bytes behind a misleading `.obf` name — sniffing wins over the name.
     const file = new File([obzBlob], "actually-a-package.obf");
 
     const loaded = await loadBoard(file);
@@ -50,8 +49,6 @@ describe("loadBoard", () => {
 
     await loadBoard(file);
 
-    // The whole point of the API: sniff and parse from a single read,
-    // never sniff-then-re-read.
     expect(arrayBuffer).toHaveBeenCalledTimes(1);
   });
 
@@ -62,8 +59,7 @@ describe("loadBoard", () => {
   });
 
   test("surfaces the OBZ extractor's error for a ZIP missing its manifest", async () => {
-    // A genuine ZIP (so it routes to the OBZ branch) whose entries omit
-    // manifest.json — the extractOBZ error must propagate unchanged.
+    // A real ZIP so isZip passes and we exercise the OBZ branch, not the OBF one.
     const zipped = await zip(
       new Map([["boards/x.obf", new TextEncoder().encode("{}")]]),
     );


### PR DESCRIPTION
Follow-up to #32. Removes comments that restated the test name or self-documenting code, and tightens the remaining one to the single non-obvious point.

- **content-vs-extension test** — dropped; the `actually-a-package.obf` filename and the test name already say it.
- **read-once test** — dropped; the test name carries the contract and the single-read assertion is self-justifying.
- **missing-manifest test** — kept but tightened to one line: why a *real* ZIP is constructed (so `isZip` passes and the OBZ branch is exercised, not the OBF one).

Test-only, no behavior change. Not in the published package (`files: ["dist", "CHANGELOG.md"]`), so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)