### PR TITLE
feat: resolve rootBoard during OBZ extraction

### DIFF
--- a/.changeset/parsed-obz-root-board.md
+++ b/.changeset/parsed-obz-root-board.md
@@ -1,0 +1,7 @@
+---
+"@shayc/open-board-format": minor
+---
+
+Add `rootBoard` to `ParsedOBZ`: `extractOBZ` and `loadOBZ` now resolve the package's entry-point board (the one `manifest.root` points at) and return it directly, so consumers no longer need to invert `manifest.paths.boards` to find the home board.
+
+Extraction is also stricter: each board's `id` must match its key in `manifest.paths.boards`. Archives where they disagree now throw `Invalid OBZ: board at "<path>" has id "<id>" but the manifest declares it as "<key>"`. Such archives were previously accepted, but their boards were unreachable by `load_board.id` navigation, so this turns a silent inconsistency into a clear error.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const loaded = await loadBoard(file);
 if (loaded.format === "obf") {
   console.log(loaded.board.buttons.length);
 } else {
-  console.log(loaded.archive.boards.size);
+  console.log(loaded.archive.rootBoard.buttons.length);
 }
 ```
 
@@ -51,21 +51,13 @@ if (loaded.format === "obf") {
 import { loadOBZ, extractOBZ } from "@shayc/open-board-format";
 
 // From a File (e.g. drag-and-drop)
-const { manifest, boards, resources } = await loadOBZ(file);
+const { rootBoard, boards, resources } = await loadOBZ(file);
 
 // Or from an ArrayBuffer (e.g. fetch response)
 const parsed = await extractOBZ(buffer);
 ```
 
-`boards` is keyed by board ID and `resources` by archive path. The manifest is the package's table of contents: `manifest.root` is the archive path of the home board, and `manifest.paths.boards` maps board IDs to paths. To get the home board:
-
-```ts
-// Validation guarantees `root` is listed in `paths.boards`, so the lookup always succeeds.
-const [rootId] = Object.entries(manifest.paths.boards).find(
-  ([, path]) => path === manifest.root,
-)!;
-const homeBoard = boards.get(rootId);
-```
+`rootBoard` is the package's home board — the one `manifest.root` points at, already resolved. `boards` is keyed by board ID and `resources` by archive path; the `manifest` is also returned if you need the raw table of contents.
 
 Resources are raw bytes. To display an image in the browser:
 
@@ -150,28 +142,28 @@ One naming convention covers the whole surface: `parse*` takes a JSON string, `v
 
 ### Types
 
-| Type                  | Description                                                                           |
-| --------------------- | ------------------------------------------------------------------------------------- |
-| `OBFBoard`            | A single communication board                                                          |
-| `OBFGrid`             | Grid layout (rows, columns, order)                                                    |
-| `OBFButton`           | A button on the board                                                                 |
-| `OBFButtonAction`     | Button action (spelling or specialty)                                                 |
-| `OBFSpellingAction`   | Spelling action (e.g., `+s`)                                                          |
-| `OBFSpecialtyAction`  | Specialty action (e.g., `:clear`)                                                     |
-| `OBFLoadBoard`        | Reference to load another board                                                       |
-| `OBFMedia`            | Common media properties (base for `OBFImage` and `OBFSound`)                          |
-| `OBFImage`            | An image resource (extends `OBFMedia`)                                                |
-| `OBFSound`            | A sound resource (alias of `OBFMedia`)                                                |
-| `OBFSymbolInfo`       | Symbol set reference                                                                  |
-| `OBFManifest`         | OBZ package manifest                                                                  |
-| `ParsedOBZ`           | Return type of `extractOBZ` / `loadOBZ` — `{ manifest, boards, resources }`           |
-| `LoadedBoard`         | Return type of `loadBoard` — `{ format: "obz", archive } \| { format: "obf", board }` |
-| `OBFID`               | Unique identifier (string, coerced from number)                                       |
-| `OBFFormatVersion`    | Format version string (e.g., `open-board-0.1`)                                        |
-| `OBFLicense`          | Licensing information                                                                 |
-| `OBFLocaleCode`       | BCP 47 locale code                                                                    |
-| `OBFLocalizedStrings` | Key-value string translations                                                         |
-| `OBFStrings`          | Multi-locale string translations                                                      |
+| Type                  | Description                                                                            |
+| --------------------- | -------------------------------------------------------------------------------------- |
+| `OBFBoard`            | A single communication board                                                           |
+| `OBFGrid`             | Grid layout (rows, columns, order)                                                     |
+| `OBFButton`           | A button on the board                                                                  |
+| `OBFButtonAction`     | Button action (spelling or specialty)                                                  |
+| `OBFSpellingAction`   | Spelling action (e.g., `+s`)                                                           |
+| `OBFSpecialtyAction`  | Specialty action (e.g., `:clear`)                                                      |
+| `OBFLoadBoard`        | Reference to load another board                                                        |
+| `OBFMedia`            | Common media properties (base for `OBFImage` and `OBFSound`)                           |
+| `OBFImage`            | An image resource (extends `OBFMedia`)                                                 |
+| `OBFSound`            | A sound resource (alias of `OBFMedia`)                                                 |
+| `OBFSymbolInfo`       | Symbol set reference                                                                   |
+| `OBFManifest`         | OBZ package manifest                                                                   |
+| `ParsedOBZ`           | Return type of `extractOBZ` / `loadOBZ` — `{ manifest, boards, rootBoard, resources }` |
+| `LoadedBoard`         | Return type of `loadBoard` — `{ format: "obz", archive } \| { format: "obf", board }`  |
+| `OBFID`               | Unique identifier (string, coerced from number)                                        |
+| `OBFFormatVersion`    | Format version string (e.g., `open-board-0.1`)                                         |
+| `OBFLicense`          | Licensing information                                                                  |
+| `OBFLocaleCode`       | BCP 47 locale code                                                                     |
+| `OBFLocalizedStrings` | Key-value string translations                                                          |
+| `OBFStrings`          | Multi-locale string translations                                                       |
 
 ### Schemas
 
@@ -186,7 +178,7 @@ import { OBFButtonSchema, OBFManifestSchema } from "@shayc/open-board-format";
 All failures throw plain `Error`. The message identifies what failed, typically with one of these prefixes:
 
 - `Invalid OBF:` — schema validation rejected an OBF board.
-- `Invalid OBZ:` — the package was rejected. On read: not a ZIP, missing manifest, or the manifest references a board file not in the archive. On write (`createOBZ`): `rootBoardId` matches no board, two boards share the same id, a board fails validation, two boards map the same media id to conflicting paths, a declared image/sound `path` has no matching resource, or a resource would overwrite a generated entry.
+- `Invalid OBZ:` — the package was rejected. On read: not a ZIP, missing manifest, the manifest references a board file not in the archive, or a board's `id` differs from the ID the manifest declares for it. On write (`createOBZ`): `rootBoardId` matches no board, two boards share the same id, a board fails validation, two boards map the same media id to conflicting paths, a declared image/sound `path` has no matching resource, or a resource would overwrite a generated entry.
 - `Invalid manifest:` — `manifest.json` failed to parse or validate, including a `root` that is not listed in `paths.boards`.
 - `Failed to unzip:` — the input passed the ZIP signature check but could not be decompressed (truncated or corrupt archive).
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A TypeScript toolkit for [Open Board Format](https://www.openboardformat.org/) �
 - **Browser and Node.js 22+** — pure ESM, works against `File` and `ArrayBuffer`.
 - **One entry point for either format** — `loadBoard` sniffs the bytes and tells you whether it found an `.obf` board or an `.obz` package.
 - **Spec-faithful round trips** — unknown fields are preserved rather than stripped, so vendor extensions allowed by the OBF spec survive `parseOBF` → `stringifyOBF`.
-- **Small footprint** — two runtime dependencies ([Zod](https://zod.dev/) and [fflate](https://github.com/101arrowz/fflate)), tree-shakeable, no side effects.
+- **Small footprint** — two runtime dependencies (Zod and [fflate](https://github.com/101arrowz/fflate)), tree-shakeable, no side effects.
 
 ## Install
 
@@ -119,12 +119,12 @@ One naming convention covers the whole surface: `parse*` takes a JSON string, `v
 
 ### OBZ (board package)
 
-| Function                                     | Description                                                   |
-| -------------------------------------------- | ------------------------------------------------------------- |
-| `loadOBZ(file)`                              | Load an OBZ package from a browser `File`                     |
-| `extractOBZ(archive)`                        | Extract boards, manifest, and resources from an `ArrayBuffer` |
-| `createOBZ(boards, rootBoardId, resources?)` | Create an OBZ package as a `Blob`                             |
-| `parseManifest(json)`                        | Parse a `manifest.json` string into a validated `OBFManifest` |
+| Function                                     | Description                                                               |
+| -------------------------------------------- | ------------------------------------------------------------------------- |
+| `loadOBZ(file)`                              | Load an OBZ package from a browser `File`                                 |
+| `extractOBZ(archive)`                        | Extract boards, manifest, root board, and resources from an `ArrayBuffer` |
+| `createOBZ(boards, rootBoardId, resources?)` | Create an OBZ package as a `Blob`                                         |
+| `parseManifest(json)`                        | Parse a `manifest.json` string into a validated `OBFManifest`             |
 
 ### Format detection
 
@@ -178,9 +178,11 @@ import { OBFButtonSchema, OBFManifestSchema } from "@shayc/open-board-format";
 All failures throw plain `Error`. The message identifies what failed, typically with one of these prefixes:
 
 - `Invalid OBF:` — schema validation rejected an OBF board.
-- `Invalid OBZ:` — the package was rejected. On read: not a ZIP, missing manifest, the manifest references a board file not in the archive, or a board's `id` differs from the ID the manifest declares for it. On write (`createOBZ`): `rootBoardId` matches no board, two boards share the same id, a board fails validation, two boards map the same media id to conflicting paths, a declared image/sound `path` has no matching resource, or a resource would overwrite a generated entry.
+- `Invalid OBZ:` — the package was rejected.
+  - On read: not a ZIP, missing manifest, the manifest references a board file not in the archive, or a board's `id` differs from the ID the manifest declares for it.
+  - On write (`createOBZ`): `rootBoardId` matches no board, two boards share the same `id`, a board fails validation, two boards map the same media `id` to conflicting paths, a declared image/sound `path` has no matching resource, or a resource would overwrite a generated entry.
 - `Invalid manifest:` — `manifest.json` failed to parse or validate, including a `root` that is not listed in `paths.boards`.
-- `Failed to unzip:` — the input passed the ZIP signature check but could not be decompressed (truncated or corrupt archive).
+- `Failed to unzip:` / `Failed to zip:` — the archive could not be decompressed (truncated or corrupt despite a valid ZIP signature) or compressed.
 
 When the root cause is a `JSON.parse` failure, the original error is preserved as `error.cause`. For finer-grained validation, drop one level down and use the Zod schemas directly with `safeParse` — the `issues` array tells you exactly which field failed.
 

--- a/src/load-board.test.ts
+++ b/src/load-board.test.ts
@@ -32,6 +32,9 @@ describe("loadBoard", () => {
     }
     expect(loaded.archive.manifest.root).toBe("boards/test-board.obf");
     expect(loaded.archive.boards.get("test-board")).toEqual(validBoard);
+    expect(loaded.archive.rootBoard).toBe(
+      loaded.archive.boards.get("test-board"),
+    );
   });
 
   test("loads a single OBF board from an ArrayBuffer", async () => {

--- a/src/load-board.ts
+++ b/src/load-board.ts
@@ -13,9 +13,9 @@ import { isZip } from "./zip";
  * ```ts
  * const loaded = await loadBoard(file);
  * if (loaded.format === "obz") {
- *   loaded.archive.boards; // ParsedOBZ
+ *   loaded.archive.rootBoard; // home board of the ParsedOBZ archive
  * } else {
- *   loaded.board;          // OBFBoard
+ *   loaded.board;             // OBFBoard
  * }
  * ```
  */

--- a/src/obz.test.ts
+++ b/src/obz.test.ts
@@ -97,6 +97,73 @@ describe("extractOBZ", () => {
       'Invalid OBZ: board "missing" declared in manifest but missing',
     );
   });
+
+  test("resolves rootBoard, including when root is not the first board", async () => {
+    const boardA: OBFBoard = {
+      format: "open-board-0.1",
+      id: "a",
+      buttons: [],
+      grid: { rows: 1, columns: 1, order: [[null]] },
+    };
+    const boardB: OBFBoard = {
+      format: "open-board-0.1",
+      id: "b",
+      buttons: [],
+      grid: { rows: 1, columns: 1, order: [[null]] },
+    };
+
+    const obzBlob = await createOBZ([boardA, boardB], "b");
+    const result = await extractOBZ(await obzBlob.arrayBuffer());
+
+    expect(result.rootBoard.id).toBe("b");
+    expect(result.rootBoard).toBe(result.boards.get("b"));
+  });
+
+  test("throws when a board's id does not match its manifest key", async () => {
+    const manifest = JSON.stringify({
+      format: "open-board-0.1",
+      root: "boards/home.obf",
+      paths: { boards: { "1": "boards/home.obf" }, images: {} },
+    });
+    const board = JSON.stringify({
+      format: "open-board-0.1",
+      id: "home",
+      buttons: [],
+      grid: { rows: 1, columns: 1, order: [[null]] },
+    });
+    const files = new Map([
+      ["manifest.json", new TextEncoder().encode(manifest)],
+      ["boards/home.obf", new TextEncoder().encode(board)],
+    ]);
+    const zipBuffer = await zip(files);
+
+    await expect(extractOBZ(zipBuffer.buffer as ArrayBuffer)).rejects.toThrow(
+      'Invalid OBZ: board at "boards/home.obf" has id "home" but the manifest declares it as "1"',
+    );
+  });
+
+  test("throws when two manifest keys map to the same board file", async () => {
+    const manifest = JSON.stringify({
+      format: "open-board-0.1",
+      root: "boards/a.obf",
+      paths: { boards: { a: "boards/a.obf", b: "boards/a.obf" }, images: {} },
+    });
+    const board = JSON.stringify({
+      format: "open-board-0.1",
+      id: "a",
+      buttons: [],
+      grid: { rows: 1, columns: 1, order: [[null]] },
+    });
+    const files = new Map([
+      ["manifest.json", new TextEncoder().encode(manifest)],
+      ["boards/a.obf", new TextEncoder().encode(board)],
+    ]);
+    const zipBuffer = await zip(files);
+
+    await expect(extractOBZ(zipBuffer.buffer as ArrayBuffer)).rejects.toThrow(
+      'Invalid OBZ: board at "boards/a.obf" has id "a" but the manifest declares it as "b"',
+    );
+  });
 });
 
 describe("loadOBZ", () => {
@@ -115,6 +182,7 @@ describe("loadOBZ", () => {
 
     expect(result.manifest.root).toBe("boards/test.obf");
     expect(result.boards.get("test")).toBeDefined();
+    expect(result.rootBoard.id).toBe("test");
   });
 });
 
@@ -316,6 +384,7 @@ describe("Integration: createOBZ and extractOBZ", () => {
     const extracted = await extractOBZ(obzBuffer);
 
     expect(extracted.manifest.root).toBe("boards/board-1.obf");
+    expect(extracted.rootBoard).toBe(extracted.boards.get("board-1"));
     expect(extracted.boards.get("board-1")).toMatchObject({
       id: "board-1",
       buttons: [{ id: "btn-1", label: "Test" }],

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -31,7 +31,7 @@ export interface ParsedOBZ {
  * @param file - A `File` handle pointing to an `.obz` archive.
  * @returns The parsed manifest, boards, root board, and binary resources.
  *
- * @throws {Error} If the file is not a valid ZIP or the manifest is missing.
+ * @throws {Error} Same failures as {@link extractOBZ}, which this delegates to.
  */
 export async function loadOBZ(file: File): Promise<ParsedOBZ> {
   const archive = await file.arrayBuffer();

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -8,6 +8,9 @@ import { isZip, unzip, zip } from "./zip";
  *
  * @property manifest  - The package table of contents.
  * @property boards    - Board ID → validated board object.
+ * @property rootBoard - The package's entry-point board — the one `manifest.root`
+ *                       points at, already resolved. Same object as
+ *                       `boards.get(rootBoard.id)`.
  * @property resources - Archive path → raw bytes for every entry in the archive,
  *                       including `manifest.json` and the `.obf` boards as well as
  *                       media such as images and sounds.
@@ -15,6 +18,7 @@ import { isZip, unzip, zip } from "./zip";
 export interface ParsedOBZ {
   manifest: OBFManifest;
   boards: Map<string, OBFBoard>;
+  rootBoard: OBFBoard;
   resources: Map<string, Uint8Array>;
 }
 
@@ -25,7 +29,7 @@ export interface ParsedOBZ {
  * read the file to an `ArrayBuffer` and pass it to {@link extractOBZ} instead.
  *
  * @param file - A `File` handle pointing to an `.obz` archive.
- * @returns The parsed manifest, boards, and binary resources.
+ * @returns The parsed manifest, boards, root board, and binary resources.
  *
  * @throws {Error} If the file is not a valid ZIP or the manifest is missing.
  */
@@ -39,9 +43,12 @@ export async function loadOBZ(file: File): Promise<ParsedOBZ> {
  *
  * @param archive - The OBZ archive as an `ArrayBuffer`.
  * @returns The parsed manifest, a map of board IDs to validated boards,
- *          and a map of file paths to their binary content.
+ *          the resolved root board, and a map of file paths to their
+ *          binary content.
  *
- * @throws {Error} If the archive is not a valid ZIP or the manifest is missing.
+ * @throws {Error} If the archive is not a valid ZIP, the manifest is missing,
+ *   a board declared in the manifest is missing or fails validation, or a
+ *   board's `id` differs from the ID the manifest declares for it.
  */
 export async function extractOBZ(archive: ArrayBuffer): Promise<ParsedOBZ> {
   if (!isZip(archive)) {
@@ -51,9 +58,9 @@ export async function extractOBZ(archive: ArrayBuffer): Promise<ParsedOBZ> {
   const entries = await unzip(archive);
 
   const manifest = extractManifest(entries);
-  const boards = extractBoards(manifest, entries);
+  const { boards, rootBoard } = extractBoards(manifest, entries);
 
-  return { manifest, boards, resources: entries };
+  return { manifest, boards, rootBoard, resources: entries };
 }
 
 /**
@@ -258,8 +265,9 @@ function extractManifest(entries: Map<string, Uint8Array>): OBFManifest {
 function extractBoards(
   manifest: OBFManifest,
   entries: Map<string, Uint8Array>,
-): Map<string, OBFBoard> {
+): { boards: Map<string, OBFBoard>; rootBoard: OBFBoard } {
   const boards = new Map<string, OBFBoard>();
+  let rootBoard: OBFBoard | undefined;
 
   for (const [id, path] of Object.entries(manifest.paths.boards)) {
     const boardBytes = entries.get(path);
@@ -271,8 +279,28 @@ function extractBoards(
     }
 
     const boardJson = new TextDecoder().decode(boardBytes);
-    boards.set(id, parseOBF(boardJson));
+    const board = parseOBF(boardJson);
+
+    if (board.id !== id) {
+      throw new Error(
+        `Invalid OBZ: board at "${path}" has id "${board.id}" but the manifest declares it as "${id}"`,
+      );
+    }
+
+    boards.set(id, board);
+
+    if (path === manifest.root) {
+      rootBoard = board;
+    }
   }
 
-  return boards;
+  if (!rootBoard) {
+    // Unreachable for validated manifests: the schema requires `root` to be
+    // listed in `paths.boards`. Kept as a guard for hand-built manifests.
+    throw new Error(
+      `Invalid OBZ: root board "${manifest.root}" not found in paths.boards`,
+    );
+  }
+
+  return { boards, rootBoard };
 }


### PR DESCRIPTION
Closes the API gap behind the README's densest snippet: getting the home board out of a parsed OBZ required consumers to invert `manifest.paths.boards` by hand (as aac-board-ai does today in `resolveRootBoardId`, plus a second copy in its tests). Design follows the reference implementations — the OpenAAC Ruby gem and cboard's react-obf both resolve `manifest.root` inside the parser.

## Changes

**`ParsedOBZ` gains `rootBoard`** (minor) — the board `manifest.root` points at, resolved during the existing extraction loop (one string comparison per board, zero extra passes). It is the same object reference as in the `boards` map, pinned by a `toBe` test. Restores read/write symmetry with `createOBZ`: everything needed to recreate an archive is now first-class on the parsed form.

**Extraction validates manifest key ↔ board `id`** (stricter) — each board's `id` must match its key in `manifest.paths.boards`. Mismatched archives previously parsed but their boards were unreachable via `load_board.id` navigation (and break the reference Ruby implementation the same way); they now throw `Invalid OBZ: board at "…" has id "…" but the manifest declares it as "…"`. This validation is also what makes `rootBoard.id` a sound substitute for a separate `rootId` field — one field instead of two. Zod's ID coercion runs first, so numeric ids (`"id": 1` vs key `"1"`) still pass.

**Why one field, not a helper** — a `getRootBoard()` function can't be typed non-optional for hand-built inputs and isn't discoverable by autocomplete; a field on the object the consumer already holds is. The unreachable-root guard inside `extractBoards` exists for TS narrowing and hand-built manifests; it's documented as such.

## Tests

Four new tests: root resolution when root is not the first board (reference equality), ID-mismatch rejection, duplicate-path rejection (two manifest keys → same file now throws deterministically via the mismatch check), and `rootBoard` assertions added to the loadOBZ/loadBoard/round-trip tests. 120 pass; README updated (root lookup snippet collapses to a destructure); minor changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)