### PR TITLE
docs: polish public API JSDoc for better IntelliSense

### DIFF
--- a/.changeset/jsdoc-public-api-polish.md
+++ b/.changeset/jsdoc-public-api-polish.md
@@ -1,0 +1,11 @@
+---
+"@shayc/open-board-format": patch
+---
+
+docs: polish public API JSDoc for better IntelliSense
+
+- Document every exported type alias (`OBFBoard`, `OBFButton`, …) so hover tooltips show a description instead of just the expanded type
+- Move `ParsedOBZ` field docs from `@property` tags onto the fields themselves so they surface in editors
+- Clarify `data_url` as an API endpoint (not a `data:` URI) and note it is outside the `data` → `path` → `url` fallback chain
+- Document `action` vs `actions` precedence per the OBF spec
+- Correct fflate compression-level scale (0–9), standardize `@throws` phrasing, example quoting, and module headers; tag `buildJsonParseErrorMessage` as `@internal`

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup (Node 22+, Vitest, 
 
 ## Related
 
-- [Open Board Format specification](https://www.openboardformat.org/docs) — the official standard and format documentation.
+- [Open Board Format specification](https://www.openboardformat.org/docs) — the official standard and format documentation. A 1:1 mirror is kept at [docs/external/open-board-format.md](docs/external/open-board-format.md) for offline reference.
 - [AAC Board AI](https://github.com/shayc/aac-board-ai) — an offline-first AAC web app built on this package, using on-device browser AI for grammar, tone, and translation ([live app](https://aacboard.app)).
 
 ## License

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Public API of `@shayc/open-board-format`.
+ */
+
+// Zod schemas and inferred types for the OBF data model
 export type {
   OBFBoard,
   OBFButton,
@@ -40,14 +45,18 @@ export {
   OBFSymbolInfoSchema,
 } from "./schema";
 
+// Single-board (.obf) parsing, validation, and serialization
 export { loadOBF, parseOBF, stringifyOBF, validateOBF } from "./obf";
 
+// Board-package (.obz) creation and extraction
 export { createOBZ, extractOBZ, loadOBZ, parseManifest } from "./obz";
 
 export type { ParsedOBZ } from "./obz";
 
+// Format-agnostic loading of .obf or .obz input
 export { loadBoard } from "./load-board";
 
 export type { LoadedBoard } from "./load-board";
 
+// ZIP helpers
 export { isZip, unzip, zip } from "./zip";

--- a/src/load-board.ts
+++ b/src/load-board.ts
@@ -1,3 +1,7 @@
+/**
+ * Format-agnostic loading of `.obf` boards and `.obz` packages.
+ */
+
 import { parseOBF } from "./obf";
 import { extractOBZ } from "./obz";
 import type { ParsedOBZ } from "./obz";
@@ -27,11 +31,11 @@ export type LoadedBoard =
  * Detect whether the input is a single OBF board or an OBZ package and load it
  * accordingly.
  *
- * The input is read once and its leading bytes are sniffed for the ZIP magic
- * prefix: a ZIP is treated as an `.obz` package, anything else as an `.obf`
- * board. This lets consumers accept either format from a single drag-and-drop,
- * file picker, or fetch response without inspecting the file extension or
- * re-deriving the OBF-vs-OBZ distinction themselves.
+ * Input that begins with the ZIP magic prefix is treated as an `.obz` package;
+ * anything else is parsed as an `.obf` board. The input is read once, so
+ * consumers can accept either format from a single drag-and-drop, file picker,
+ * or fetch response without inspecting the file extension or re-deriving the
+ * OBF-vs-OBZ distinction themselves.
  *
  * @param input - A `File` handle or `ArrayBuffer` holding `.obf` or `.obz` content.
  * @returns A discriminated union tagged by `format`.

--- a/src/obf.ts
+++ b/src/obf.ts
@@ -1,3 +1,7 @@
+/**
+ * Parsing, validation, and serialization for single `.obf` board files.
+ */
+
 import type { OBFBoard } from "./schema";
 import { OBFBoardSchema } from "./schema";
 
@@ -8,7 +12,12 @@ function stripBom(text: string): string {
   return text.startsWith(UTF8_BOM) ? text.slice(1) : text;
 }
 
-/** Build a descriptive JSON parse-failure message, preserving the engine's reason when available. */
+/**
+ * Build a descriptive JSON parse-failure message, preserving the engine's
+ * reason when available.
+ *
+ * @internal Exported for reuse by the OBZ module — not part of the public API.
+ */
 export function buildJsonParseErrorMessage(
   label: string,
   error: unknown,
@@ -28,7 +37,7 @@ export function buildJsonParseErrorMessage(
  * @param json - The JSON string to parse.
  * @returns The validated board object.
  *
- * @throws {Error} If the JSON is malformed or does not conform to the OBF schema.
+ * @throws {Error} If the JSON is malformed or fails schema validation.
  */
 export function parseOBF(json: string): OBFBoard {
   const sanitized = stripBom(json);
@@ -66,7 +75,7 @@ export async function loadOBF(file: File): Promise<OBFBoard> {
  * @param data - The value to validate.
  * @returns The validated board object.
  *
- * @throws {Error} If the value does not conform to the OBF schema.
+ * @throws {Error} If the value fails schema validation.
  */
 export function validateOBF(data: unknown): OBFBoard {
   const result = OBFBoardSchema.safeParse(data);

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -1,3 +1,7 @@
+/**
+ * Creation and extraction of `.obz` board packages.
+ */
+
 import { buildJsonParseErrorMessage, parseOBF } from "./obf";
 import type { OBFBoard, OBFManifest } from "./schema";
 import { OBFBoardSchema, OBFManifestSchema } from "./schema";
@@ -5,20 +9,22 @@ import { isZip, unzip, zip } from "./zip";
 
 /**
  * Fully extracted contents of an `.obz` archive.
- *
- * @property manifest  - The package table of contents.
- * @property boards    - Board ID → validated board object.
- * @property rootBoard - The package's entry-point board — the one `manifest.root`
- *                       points at, already resolved. Same object as
- *                       `boards.get(rootBoard.id)`.
- * @property resources - Archive path → raw bytes for every entry in the archive,
- *                       including `manifest.json` and the `.obf` boards as well as
- *                       media such as images and sounds.
  */
 export interface ParsedOBZ {
+  /** The package's table of contents. */
   manifest: OBFManifest;
+  /** Validated board objects keyed by board ID. */
   boards: Map<string, OBFBoard>;
+  /**
+   * The package's entry-point board — the one `manifest.root` points at,
+   * already resolved. Same object as `boards.get(rootBoard.id)`.
+   */
   rootBoard: OBFBoard;
+  /**
+   * Raw bytes for every entry in the archive, keyed by archive path —
+   * including `manifest.json` and the `.obf` boards as well as media
+   * such as images and sounds.
+   */
   resources: Map<string, Uint8Array>;
 }
 
@@ -104,9 +110,9 @@ export function parseManifest(json: string): OBFManifest {
  * @returns A `Blob` containing the compressed OBZ archive.
  *
  * @throws {Error} If `rootBoardId` does not match any of the supplied boards.
- * @throws {Error} If two supplied boards share the same id.
+ * @throws {Error} If two supplied boards share the same ID.
  * @throws {Error} If a supplied board fails schema validation.
- * @throws {Error} If two boards declare the same media id with conflicting paths.
+ * @throws {Error} If two boards declare the same media ID with conflicting paths.
  * @throws {Error} If a board declares an image or sound `path` with no matching entry in `resources`.
  * @throws {Error} If a `resources` entry would overwrite the generated `manifest.json` or a board file.
  */
@@ -202,7 +208,7 @@ export async function createOBZ(
  * Walk every board's media collection and produce the `{ id -> path }` map
  * the spec calls "redundant but still required" for the OBZ manifest.
  *
- * Throws when two boards declare the same media id with conflicting paths
+ * Throws when two boards declare the same media ID with conflicting paths
  * — a silent OBZ that points at a non-existent file is worse than a clear error.
  */
 function collectMediaPaths(

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5,9 +5,6 @@
  * between Augmentative and Alternative Communication (AAC) applications.
  *
  * Official OBF specification: https://www.openboardformat.org/docs
- *
- * @author Shay Cojocaru
- * @license MIT
  */
 
 import { z } from "zod";
@@ -38,25 +35,44 @@ export const OBFIDSchema = z
   .union([z.string(), z.number()])
   .transform((val) => String(val))
   .pipe(z.string().min(1));
-export type OBFID = z.infer<typeof OBFIDSchema>;
 
 /**
- * Format version of the Open Board Format, e.g., 'open-board-0.1'.
+ * Unique board-element identifier, coerced to a non-empty string.
+ * See {@link OBFIDSchema}.
  */
+export type OBFID = z.infer<typeof OBFIDSchema>;
+
+/** Format version of the Open Board Format, e.g., `open-board-0.1`. */
 export const OBFFormatVersionSchema = z.string().regex(/^open-board-.+$/);
+
+/**
+ * Format version of the Open Board Format, e.g., `open-board-0.1`.
+ * See {@link OBFFormatVersionSchema}.
+ */
 export type OBFFormatVersion = z.infer<typeof OBFFormatVersionSchema>;
 
 /**
- * Locale identifier, typically a BCP 47 language tag (e.g., 'en', 'en-US', 'fr-CA').
- * Not strictly validated — any string is accepted.
+ * Locale identifier, typically a BCP 47 language tag (e.g., `en`, `en-US`,
+ * `fr-CA`). Not strictly validated — any string is accepted.
  */
 export const OBFLocaleCodeSchema = z.string();
+
+/**
+ * Locale identifier, typically a BCP 47 language tag, e.g., `en`, `en-US`.
+ * See {@link OBFLocaleCodeSchema}.
+ */
 export type OBFLocaleCode = z.infer<typeof OBFLocaleCodeSchema>;
 
 /**
- * Key–value pairs mapping symbolic names to their translations in a single locale.
+ * Translations for a single locale, keyed by the source string,
+ * e.g., `{ "hello": "hola" }`.
  */
 export const OBFLocalizedStringsSchema = z.record(z.string(), z.string());
+
+/**
+ * Translations for a single locale, keyed by the source string.
+ * See {@link OBFLocalizedStringsSchema}.
+ */
 export type OBFLocalizedStrings = z.infer<typeof OBFLocalizedStringsSchema>;
 
 /**
@@ -64,38 +80,54 @@ export type OBFLocalizedStrings = z.infer<typeof OBFLocalizedStringsSchema>;
  * e.g., `{ en: { greeting: "Hello" }, fr: { greeting: "Bonjour" } }`.
  */
 export const OBFStringsSchema = z.record(z.string(), OBFLocalizedStringsSchema);
+
+/**
+ * Locale-keyed dictionary of translated strings.
+ * See {@link OBFStringsSchema}.
+ */
 export type OBFStrings = z.infer<typeof OBFStringsSchema>;
 
 /**
  * Spelling action: a `+` prefix followed by the text to append,
- * e.g., `"+hello"`.
+ * e.g., `+hello`.
  */
 export const OBFSpellingActionSchema = z.string().regex(/^\+.+$/);
+
+/**
+ * Spelling action: a `+` prefix followed by the text to append, e.g., `+hello`.
+ * See {@link OBFSpellingActionSchema}.
+ */
 export type OBFSpellingAction = z.infer<typeof OBFSpellingActionSchema>;
 
 /**
- * Specialty action prefixed with `:`, e.g., `":clear"`.
+ * Specialty action prefixed with `:`, e.g., `:clear`.
  * Custom extensions use the `:ext_` prefix.
  */
 export const OBFSpecialtyActionSchema = z
   .string()
   .regex(/^:[a-z][a-z0-9_-]*$/i);
-export type OBFSpecialtyAction = z.infer<typeof OBFSpecialtyActionSchema>;
 
 /**
- * Union of spelling and specialty actions that a button can trigger.
+ * Specialty action prefixed with `:`, e.g., `:clear`.
+ * See {@link OBFSpecialtyActionSchema}.
  */
+export type OBFSpecialtyAction = z.infer<typeof OBFSpecialtyActionSchema>;
+
+/** Union of spelling and specialty actions that a button can trigger. */
 export const OBFButtonActionSchema = z.union([
   OBFSpellingActionSchema,
   OBFSpecialtyActionSchema,
 ]);
-export type OBFButtonAction = z.infer<typeof OBFButtonActionSchema>;
 
 /**
- * License terms and attribution for a resource.
+ * Union of spelling and specialty actions that a button can trigger.
+ * See {@link OBFButtonActionSchema}.
  */
+export type OBFButtonAction = z.infer<typeof OBFButtonActionSchema>;
+
+/** License terms and attribution for a resource. */
 export const OBFLicenseSchema = z.looseObject({
-  /** Type of the license, e.g., 'CC-BY-SA'. */
+  /** Type of the license, e.g., `CC-BY-SA`. */
   type: z.string(),
   /** URL to the license terms. */
   copyright_notice_url: OBFOptionalUrlSchema,
@@ -109,44 +141,62 @@ export const OBFLicenseSchema = z.looseObject({
   author_email: OBFOptionalEmailSchema,
 });
 
+/**
+ * License terms and attribution for a resource.
+ * See {@link OBFLicenseSchema}.
+ */
 export type OBFLicense = z.infer<typeof OBFLicenseSchema>;
 
 /**
  * Common properties for media resources (images and sounds).
  *
  * When multiple references are provided, they should be used in the following order:
- * 1. data
- * 2. path
- * 3. url
+ * 1. `data`
+ * 2. `path`
+ * 3. `url`
+ *
+ * `data_url` is not part of this fallback chain — it is an API endpoint for
+ * retrieving information about the resource, not an alternative source of
+ * the media bytes.
  */
 export const OBFMediaSchema = z.looseObject({
   /** Unique identifier for the media resource. */
   id: OBFIDSchema,
-  /** Data URI containing the media data. */
+  /** Media data inlined as a `data:` URI. */
   data: z.string().optional(),
-  /** Path to the media file within an .obz package. */
+  /** Path to the media file within an `.obz` package. */
   path: z.string().optional(),
-  /** Data URL to fetch the media programmatically. */
+  /**
+   * URL of an API endpoint for fetching the media programmatically —
+   * not a `data:` URI (that is `data`).
+   */
   data_url: OBFOptionalUrlSchema,
   /** URL to the media resource. */
   url: OBFOptionalUrlSchema,
-  /** MIME type of the media, e.g., 'image/png', 'audio/mpeg'. */
+  /** MIME type of the media, e.g., `image/png`, `audio/mpeg`. */
   content_type: z.string().optional(),
   /** Licensing information for the media. */
   license: OBFLicenseSchema.optional(),
 });
 
+/**
+ * Common properties for media resources (images and sounds).
+ * See {@link OBFMediaSchema}.
+ */
 export type OBFMedia = z.infer<typeof OBFMediaSchema>;
 
-/**
- * Reference to a symbol in a proprietary symbol set (e.g., SymbolStix).
- */
+/** Reference to a symbol in a proprietary symbol set (e.g., SymbolStix). */
 export const OBFSymbolInfoSchema = z.looseObject({
-  /** Name of the symbol set, e.g., 'symbolstix'. */
+  /** Name of the symbol set, e.g., `symbolstix`. */
   set: z.string(),
   /** Filename of the symbol within the set. */
   filename: z.string(),
 });
+
+/**
+ * Reference to a symbol in a proprietary symbol set.
+ * See {@link OBFSymbolInfoSchema}.
+ */
 export type OBFSymbolInfo = z.infer<typeof OBFSymbolInfoSchema>;
 
 /**
@@ -167,30 +217,45 @@ export const OBFImageSchema = OBFMediaSchema.extend({
   /** Height of the image in pixels. */
   height: z.number().optional(),
 });
+
+/**
+ * Image resource with optional symbol and dimension properties.
+ * See {@link OBFImageSchema}.
+ */
 export type OBFImage = z.infer<typeof OBFImageSchema>;
 
 /**
  * Audio resource. Identical to {@link OBFMediaSchema} — no additional properties.
  */
 export const OBFSoundSchema = OBFMediaSchema;
-export type OBFSound = z.infer<typeof OBFSoundSchema>;
 
 /**
- * Reference to another board, resolved by ID, path, or URL.
+ * Audio resource, identical to {@link OBFMedia}.
+ * See {@link OBFSoundSchema}.
  */
+export type OBFSound = z.infer<typeof OBFSoundSchema>;
+
+/** Reference to another board, resolved by ID, path, or URL. */
 export const OBFLoadBoardSchema = z.looseObject({
   /** Unique identifier of the board to load. */
   id: OBFOptionalIDSchema,
   /** Name of the board to load. */
   name: z.string().optional(),
-  /** Data URL to fetch the board programmatically. */
+  /**
+   * URL of an API endpoint for fetching the board programmatically —
+   * not a `data:` URI.
+   */
   data_url: OBFOptionalUrlSchema,
   /** URL to access the board via a web browser. */
   url: OBFOptionalUrlSchema,
-  /** Path to the board within an .obz package. */
+  /** Path to the board within an `.obz` package. */
   path: z.string().optional(),
 });
 
+/**
+ * Reference to another board, resolved by ID, path, or URL.
+ * See {@link OBFLoadBoardSchema}.
+ */
 export type OBFLoadBoard = z.infer<typeof OBFLoadBoardSchema>;
 
 /**
@@ -207,15 +272,21 @@ export const OBFButtonSchema = z.looseObject({
   image_id: OBFOptionalIDSchema,
   /** Identifier of the sound associated with the button. */
   sound_id: OBFOptionalIDSchema,
-  /** Action associated with the button. */
+  /**
+   * Action triggered by the button. When `actions` is also set, this is
+   * the single-action fallback for apps that support one action per button.
+   */
   action: OBFButtonActionSchema.optional(),
-  /** List of multiple actions for the button, executed in order. */
+  /**
+   * Multiple actions executed in order. Apps that support it should
+   * prefer this over the single `action` fallback.
+   */
   actions: z.array(OBFButtonActionSchema).optional(),
   /** Information to load another board when this button is activated. */
   load_board: OBFLoadBoardSchema.optional(),
-  /** Background color of the button in 'rgb' or 'rgba' format. */
+  /** Background color of the button in `rgb` or `rgba` format. */
   background_color: z.string().optional(),
-  /** Border color of the button in 'rgb' or 'rgba' format. */
+  /** Border color of the button in `rgb` or `rgba` format. */
   border_color: z.string().optional(),
   /** Vertical position for absolute positioning (0.0 to 1.0). */
   top: z.number().min(0).max(1).optional(),
@@ -227,6 +298,10 @@ export const OBFButtonSchema = z.looseObject({
   height: z.number().min(0).max(1).optional(),
 });
 
+/**
+ * Interactive element on a board, optionally linked to images, sounds, and
+ * actions. See {@link OBFButtonSchema}.
+ */
 export type OBFButton = z.infer<typeof OBFButtonSchema>;
 
 /**
@@ -250,17 +325,22 @@ export const OBFGridSchema = z
   .refine((g) => g.order.every((row) => row.length === g.columns), {
     message: "Each grid row must have length equal to columns",
   });
+
+/**
+ * Row-and-column layout that arranges buttons by their IDs.
+ * See {@link OBFGridSchema}.
+ */
 export type OBFGrid = z.infer<typeof OBFGridSchema>;
 
 /**
  * Root object of an `.obf` file: the complete definition of a single communication board.
  */
 export const OBFBoardSchema = z.looseObject({
-  /** Format version of the Open Board Format, e.g., 'open-board-0.1'. */
+  /** Format version of the Open Board Format, e.g., `open-board-0.1`. */
   format: OBFFormatVersionSchema,
   /** Unique identifier for the board. */
   id: OBFIDSchema,
-  /** Locale of the board as a BCP 47 language tag, e.g., 'en', 'en-US'. */
+  /** Locale of the board as a BCP 47 language tag, e.g., `en`, `en-US`. */
   locale: OBFLocaleCodeSchema.optional(),
   /** List of buttons on the board. */
   buttons: z.array(OBFButtonSchema),
@@ -282,6 +362,10 @@ export const OBFBoardSchema = z.looseObject({
   strings: OBFStringsSchema.optional(),
 });
 
+/**
+ * The complete definition of a single communication board — root object of
+ * an `.obf` file. See {@link OBFBoardSchema}.
+ */
 export type OBFBoard = z.infer<typeof OBFBoardSchema>;
 
 /**
@@ -289,9 +373,9 @@ export type OBFBoard = z.infer<typeof OBFBoardSchema>;
  */
 export const OBFManifestSchema = z
   .looseObject({
-    /** Format version of the Open Board Format, e.g., 'open-board-0.1'. */
+    /** Format version of the Open Board Format, e.g., `open-board-0.1`. */
     format: OBFFormatVersionSchema,
-    /** Path to the root board within the .obz package. */
+    /** Path to the root board within the `.obz` package. */
     root: z.string(),
     /** Mapping of IDs to paths for boards, images, and sounds. */
     paths: z.looseObject({
@@ -307,4 +391,9 @@ export const OBFManifestSchema = z
     message: "root must be listed in paths.boards",
     path: ["root"],
   });
+
+/**
+ * Table of contents for an `.obz` package, mapping resource IDs to their
+ * archive paths. See {@link OBFManifestSchema}.
+ */
 export type OBFManifest = z.infer<typeof OBFManifestSchema>;

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -1,3 +1,7 @@
+/**
+ * Minimal ZIP helpers over fflate: signature sniffing, unzip, and zip.
+ */
+
 import { unzip as fflateUnzip, zip as fflateZip } from "fflate";
 
 /**
@@ -9,7 +13,7 @@ import { unzip as fflateUnzip, zip as fflateZip } from "fflate";
  */
 const ZIP_MAGIC = [0x50, 0x4b] as const;
 
-/** Balanced speed-vs-size deflate level used by fflate (1–9 scale). */
+/** Balanced speed-vs-size deflate level, on fflate's 0–9 scale (0 = store). */
 const COMPRESSION_LEVEL = 6;
 
 /**
@@ -18,7 +22,7 @@ const COMPRESSION_LEVEL = 6;
  * @param archive - The ZIP archive as an `ArrayBuffer`.
  * @returns A map of file paths to their decompressed content.
  *
- * @throws {Error} If decompression fails.
+ * @throws {Error} If the archive is corrupt or cannot be decompressed.
  */
 export function unzip(archive: ArrayBuffer): Promise<Map<string, Uint8Array>> {
   return new Promise((resolve, reject) => {
@@ -47,7 +51,7 @@ export function unzip(archive: ArrayBuffer): Promise<Map<string, Uint8Array>> {
  * @param entries - A map of file paths to their content bytes.
  * @returns The compressed archive as a `Uint8Array`.
  *
- * @throws {Error} If compression fails.
+ * @throws {Error} If fflate fails to compress an entry.
  */
 export function zip(
   entries: Map<string, Uint8Array | ArrayBuffer>,


### PR DESCRIPTION
## Summary

Comment-only pass over the public API surface. No runtime behavior changes — 120/120 tests pass, lint/typecheck/format clean.

The driving goal: JSDoc on exports is the library's IntelliSense UI, and some of the best existing docs weren't reaching it.

### Structural fixes (affect what consumers see on hover)

- **Every exported type alias now has JSDoc** (`OBFBoard`, `OBFButton`, `ParsedOBZ` siblings, …). The schema consts were documented, but JSDoc does not carry over through `z.infer` to the alias — hovering `OBFBoard` showed a bare expanded type. Each alias gets the schema's summary sentence plus a `{@link}` to its runtime validator. Verified the docs land in the emitted `dist/index.d.mts`.
- **`ParsedOBZ` field docs moved from `@property` tags onto the fields.** `@property` on an interface doesn't attach to members, so descriptions like "same object as `boards.get(rootBoard.id)`" were invisible in editors. Also the only place in the codebase using that style.

### Accuracy fixes (verified against the OBF spec Google Doc)

- **`data_url`** was described as "Data URL…", which reads as a `data:` URI — confusing next to the sibling `data` field that *is* one. Now described per spec as a programmatic API endpoint, with an explicit note on `OBFMediaSchema` that it is outside the `data` → `path` → `url` fallback chain.
- **`action` vs `actions` precedence** documented per spec: `actions` is the full in-order list; `action` is the single-action fallback for apps that support one action per button.
- **fflate compression level** is a 0–9 scale (0 = store), not 1–9.

### Consistency

- Uniform `@throws` phrasing ("fails schema validation"); concrete causes for the zip helpers instead of tautologies
- Backticks for all literals in examples (`open-board-0.1`, `:clear`, `CC-BY-SA`, …)
- One-line JSDoc for single-sentence summaries, blocks for multi-sentence
- Brief module headers on all source files, section grouping in `index.ts`; dropped `@author`/`@license` tags that duplicate package.json
- `buildJsonParseErrorMessage` tagged `@internal` (exported for cross-module reuse, not part of the public API)

Includes a patch changeset since the published `.d.mts` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)