### PR TITLE
docs: ship the OBF spec mirror in the npm package

### DIFF
--- a/.changeset/ship-spec-mirror.md
+++ b/.changeset/ship-spec-mirror.md
@@ -1,0 +1,10 @@
+---
+"@shayc/open-board-format": patch
+---
+
+docs: ship the OBF spec mirror (`docs/external/open-board-format.md`) in the npm package
+
+The README already points at this file; including it makes that link resolve
+inside `node_modules` and gives offline tooling and coding agents the full
+format semantics (specialty actions, string-list fallback, ID uniqueness)
+that type declarations can't carry.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "files": [
     "dist",
+    "docs/external/open-board-format.md",
     "CHANGELOG.md"
   ],
   "scripts": {


### PR DESCRIPTION
## Summary

Adds `docs/external/open-board-format.md` — the verified 1:1 mirror of the official OBF spec — to the npm package via the `files` field.

## Why

- The published README already links to this file relatively; without it the link dangles inside `node_modules`. Now it resolves in both contexts (GitHub and tarball).
- Behavioral format semantics can't live in type declarations: the suggested specialty actions (`:space`, `:home`, `:speak`, `:clear`, `:backspace`), string-list fallback rules, ID uniqueness across an `.obz`, color handling guidance. The spec is the only place these exist, and the official source is a JS-rendered site wrapping a Google Doc — effectively unreachable for offline/sandboxed tooling and coding agents reading `node_modules`.
- Cost: +8.3 kB compressed (27.2 → 35.5 kB), zero runtime impact, no exports changes. The spec text is static (last substantive change 2019). CC-BY 4.0 attribution is embedded in the file itself.

Verified with `npm pack --dry-run`: file lands at `docs/external/open-board-format.md`, 8 files total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)