### PR TITLE
feat: throw typed OBFError with discriminated error.info

### DIFF
--- a/.changeset/typed-obf-errors.md
+++ b/.changeset/typed-obf-errors.md
@@ -1,0 +1,9 @@
+---
+"@shayc/open-board-format": minor
+---
+
+Throw a typed `OBFError` instead of plain `Error`. Every failure now carries a discriminated `error.info`, so consumers branch on `error.info.code` (e.g. `"missing-resource"`, `"invalid-board"`, `"not-zip"`) and read structured fields off each variant — no message parsing.
+
+- New exports: `OBFError` (class), and the `OBFErrorInfo`, `OBFErrorCode`, and `OBFIssue` types.
+- Validation failures (`invalid-board`, `invalid-manifest`) carry the Zod `issues` list plus the underlying `ZodError` as `error.cause`; decode failures (`not-json`, `unreadable-zip`, `zip-failed`) carry the underlying error as `cause`.
+- **Breaking:** thrown errors are now `OBFError` (`error.name` is `"OBFError"`) and message strings changed. Branch on `error.info.code` rather than matching `error.message`. The internal `buildJsonParseErrorMessage` helper was removed.

--- a/.changeset/typed-obf-errors.md
+++ b/.changeset/typed-obf-errors.md
@@ -5,5 +5,6 @@
 Throw a typed `OBFError` instead of plain `Error`. Every failure now carries a discriminated `error.info`, so consumers branch on `error.info.code` (e.g. `"missing-resource"`, `"invalid-board"`, `"not-zip"`) and read structured fields off each variant — no message parsing.
 
 - New exports: `OBFError` (class), and the `OBFErrorInfo`, `OBFErrorCode`, and `OBFIssue` types.
-- Validation failures (`invalid-board`, `invalid-manifest`) carry the Zod `issues` list plus the underlying `ZodError` as `error.cause`; decode failures (`not-json`, `unreadable-zip`, `zip-failed`) carry the underlying error as `cause`.
+- Validation failures (`invalid-board`, `invalid-manifest`) expose the Zod `issues` list on `error.info`. The underlying error — the `ZodError`, or the `JSON.parse`/fflate failure for `not-json`/`unreadable-zip`/`zip-failed` — is always on the standard `error.cause` and never duplicated on `info`.
+- An `internal` code marks a library-invariant violation (a bug here), not something callers can recover from.
 - **Breaking:** thrown errors are now `OBFError` (`error.name` is `"OBFError"`) and message strings changed. Branch on `error.info.code` rather than matching `error.message`. The internal `buildJsonParseErrorMessage` helper was removed.

--- a/README.md
+++ b/README.md
@@ -202,13 +202,13 @@ try {
 
 The `code` values, grouped by what they describe:
 
-| Group       | `info.code`         | Key fields                       |
+| Group       | `info.code`         | Key fields (on `info`)           |
 | ----------- | ------------------- | -------------------------------- |
-| Decoding    | `not-json`          | `source`, `cause`                |
+| Decoding    | `not-json`          | `source`                         |
 |             | `not-zip`           | —                                |
-|             | `unreadable-zip`    | `cause`                          |
-| Validation  | `invalid-board`     | `issues`, `cause`, `boardId?`    |
-|             | `invalid-manifest`  | `issues`, `cause`                |
+|             | `unreadable-zip`    | —                                |
+| Validation  | `invalid-board`     | `issues`, `boardId?`             |
+|             | `invalid-manifest`  | `issues`                         |
 | Read (OBZ)  | `missing-manifest`  | —                                |
 |             | `missing-board`     | `boardId`, `path`                |
 |             | `board-id-mismatch` | `path`, `declaredId`, `actualId` |
@@ -217,9 +217,10 @@ The `code` values, grouped by what they describe:
 |             | `missing-resource`  | `kind`, `mediaId`, `path`        |
 |             | `conflicting-paths` | `kind`, `mediaId`, `paths`       |
 |             | `path-collision`    | `path`                           |
-|             | `zip-failed`        | `cause`                          |
+|             | `zip-failed`        | —                                |
+| Internal    | `internal`          | `detail`                         |
 
-`OBFErrorInfo` and `OBFErrorCode` are exported for exhaustive handling. Validation failures carry the underlying `ZodError` as `error.cause`, so you can call `z.treeifyError(error.cause)` for nested, UI-friendly output; for `not-json` / `*-zip` failures, `cause` is the underlying parser or fflate error. The `issues` array is Zod's issue type, re-exported as `OBFIssue`.
+`OBFErrorInfo` and `OBFErrorCode` are exported for exhaustive handling. The underlying error, when there is one, is always on the standard `error.cause` — never duplicated on `info`. Validation failures (`invalid-board`, `invalid-manifest`) put the `ZodError` there, so you can call `z.treeifyError(error.cause)` for nested, UI-friendly output, while `info.issues` (Zod's issue type, re-exported as `OBFIssue`) gives you the flat list directly. For `not-json` / `*-zip` failures `error.cause` is the underlying parser or fflate error. An `internal` code signals a bug in this library that callers can't recover from — please report it.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -175,16 +175,51 @@ import { OBFButtonSchema, OBFManifestSchema } from "@shayc/open-board-format";
 
 ## Errors
 
-All failures throw plain `Error`. The message identifies what failed, typically with one of these prefixes:
+Every failure throws an `OBFError`. Branch on `error.info.code` — a discriminated union where each `code` carries exactly the fields relevant to that failure. Don't match on `error.message`; the message is human-readable and may change between releases.
 
-- `Invalid OBF:` — schema validation rejected an OBF board.
-- `Invalid OBZ:` — the package was rejected.
-  - On read: not a ZIP, missing manifest, the manifest references a board file not in the archive, or a board's `id` differs from the ID the manifest declares for it.
-  - On write (`createOBZ`): `rootBoardId` matches no board, two boards share the same `id`, a board fails validation, two boards map the same media `id` to conflicting paths, a declared image/sound `path` has no matching resource, or a resource would overwrite a generated entry.
-- `Invalid manifest:` — `manifest.json` failed to parse or validate, including a `root` that is not listed in `paths.boards`.
-- `Failed to unzip:` / `Failed to zip:` — the archive could not be decompressed (truncated or corrupt despite a valid ZIP signature) or compressed.
+```ts
+import { loadBoard, OBFError } from "@shayc/open-board-format";
 
-When the root cause is a `JSON.parse` failure, the original error is preserved as `error.cause`. For finer-grained validation, drop one level down and use the Zod schemas directly with `safeParse` — the `issues` array tells you exactly which field failed.
+try {
+  await loadBoard(file);
+} catch (error) {
+  if (!(error instanceof OBFError)) throw error;
+
+  switch (error.info.code) {
+    case "missing-resource":
+      // `kind`, `mediaId`, and `path` are all typed and present here
+      console.warn(`Missing ${error.info.kind} at ${error.info.path}`);
+      break;
+    case "invalid-board":
+      // `issues` is the Zod issue list — which field failed and why
+      console.error(error.info.issues);
+      break;
+    default:
+      console.error(error.message);
+  }
+}
+```
+
+The `code` values, grouped by what they describe:
+
+| Group       | `info.code`         | Key fields                       |
+| ----------- | ------------------- | -------------------------------- |
+| Decoding    | `not-json`          | `source`, `cause`                |
+|             | `not-zip`           | —                                |
+|             | `unreadable-zip`    | `cause`                          |
+| Validation  | `invalid-board`     | `issues`, `cause`, `boardId?`    |
+|             | `invalid-manifest`  | `issues`, `cause`                |
+| Read (OBZ)  | `missing-manifest`  | —                                |
+|             | `missing-board`     | `boardId`, `path`                |
+|             | `board-id-mismatch` | `path`, `declaredId`, `actualId` |
+| Write (OBZ) | `unknown-root`      | `rootBoardId`                    |
+|             | `duplicate-board`   | `boardId`                        |
+|             | `missing-resource`  | `kind`, `mediaId`, `path`        |
+|             | `conflicting-paths` | `kind`, `mediaId`, `paths`       |
+|             | `path-collision`    | `path`                           |
+|             | `zip-failed`        | `cause`                          |
+
+`OBFErrorInfo` and `OBFErrorCode` are exported for exhaustive handling. Validation failures carry the underlying `ZodError` as `error.cause`, so you can call `z.treeifyError(error.cause)` for nested, UI-friendly output; for `not-json` / `*-zip` failures, `cause` is the underlying parser or fflate error. The `issues` array is Zod's issue type, re-exported as `OBFIssue`.
 
 ## Security
 

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "vitest";
+import { OBFError } from "./errors";
+import type { OBFErrorInfo } from "./errors";
+import { createOBZ, extractOBZ, parseManifest } from "./obz";
+import { parseOBF, validateOBF } from "./obf";
+import type { OBFBoard } from "./schema";
+
+const board = (overrides: Partial<OBFBoard> = {}): OBFBoard => ({
+  format: "open-board-0.1",
+  id: "b",
+  buttons: [],
+  grid: { rows: 1, columns: 1, order: [[null]] },
+  ...overrides,
+});
+
+/**
+ * Switching on `info.code` narrows to each variant's fields with no casts.
+ * The `default` arm is reachable as a real union, and adding a new variant to
+ * `OBFErrorInfo` without handling it here would be a compile error.
+ */
+function summarize(info: OBFErrorInfo): string {
+  switch (info.code) {
+    case "missing-resource":
+      return `${info.kind}:${info.mediaId}:${info.path}`;
+    case "invalid-board":
+    case "invalid-manifest":
+      return `${info.code}:${info.issues.length}`;
+    default:
+      return info.code;
+  }
+}
+
+describe("OBFError", () => {
+  test("is an Error subclass with name 'OBFError' and a structured info", () => {
+    const error = new OBFError({ code: "not-zip" });
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(OBFError);
+    expect(error.name).toBe("OBFError");
+    expect(error.info.code).toBe("not-zip");
+    expect(typeof error.message).toBe("string");
+    expect(error.message.length).toBeGreaterThan(0);
+  });
+
+  test("threads `cause` for variants that carry one", () => {
+    const root = new SyntaxError("boom");
+    const error = new OBFError({
+      code: "not-json",
+      source: "board",
+      cause: root,
+    });
+
+    expect(error.cause).toBe(root);
+  });
+
+  test("omits `cause` for variants that have none", () => {
+    expect(new OBFError({ code: "not-zip" }).cause).toBeUndefined();
+  });
+
+  test("derives a non-empty message for the zip-failed variant", () => {
+    const error = new OBFError({
+      code: "zip-failed",
+      cause: new Error("boom"),
+    });
+
+    expect(error.info.code).toBe("zip-failed");
+    expect(error.message).toContain("ZIP archive");
+    expect(error.cause).toBeInstanceOf(Error);
+  });
+
+  test("info discriminates: narrowing on `code` exposes that variant's fields", () => {
+    expect(
+      summarize({
+        code: "missing-resource",
+        kind: "image",
+        mediaId: "i1",
+        path: "images/i1.png",
+      }),
+    ).toBe("image:i1:images/i1.png");
+
+    expect(summarize({ code: "not-zip" })).toBe("not-zip");
+  });
+});
+
+describe("thrown OBFError.info across the surface", () => {
+  test("parseOBF → not-json on malformed JSON", () => {
+    let info: OBFErrorInfo | undefined;
+    try {
+      parseOBF("{ not json ");
+    } catch (error) {
+      info = (error as OBFError).info;
+    }
+
+    expect(info).toMatchObject({ code: "not-json", source: "board" });
+  });
+
+  test("validateOBF → invalid-board carries non-empty issues", () => {
+    let error: OBFError | undefined;
+    try {
+      validateOBF({ id: "x" });
+    } catch (caught) {
+      error = caught as OBFError;
+    }
+
+    expect(error?.info.code).toBe("invalid-board");
+    if (error?.info.code === "invalid-board") {
+      expect(error.info.issues.length).toBeGreaterThan(0);
+      expect(error.info.issues[0]).toHaveProperty("message");
+    }
+  });
+
+  test("parseManifest → invalid-manifest carries issues", () => {
+    let error: OBFError | undefined;
+    try {
+      parseManifest(JSON.stringify({ format: "nope" }));
+    } catch (caught) {
+      error = caught as OBFError;
+    }
+
+    expect(error?.info.code).toBe("invalid-manifest");
+    if (error?.info.code === "invalid-manifest") {
+      expect(error.info.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("extractOBZ → not-zip for non-archive bytes", async () => {
+    await expect(extractOBZ(new ArrayBuffer(4))).rejects.toMatchObject({
+      info: { code: "not-zip" },
+    });
+  });
+
+  test("createOBZ → unknown-root names the offending id", async () => {
+    await expect(createOBZ([board()], "missing")).rejects.toMatchObject({
+      info: { code: "unknown-root", rootBoardId: "missing" },
+    });
+  });
+
+  test("createOBZ → duplicate-board names the repeated id", async () => {
+    await expect(createOBZ([board(), board()], "b")).rejects.toMatchObject({
+      info: { code: "duplicate-board", boardId: "b" },
+    });
+  });
+
+  test("createOBZ → missing-resource names kind, id, and path", async () => {
+    const withImage = board({
+      images: [{ id: "i1", path: "images/i1.png" }],
+    });
+
+    await expect(createOBZ([withImage], "b")).rejects.toMatchObject({
+      info: {
+        code: "missing-resource",
+        kind: "image",
+        mediaId: "i1",
+        path: "images/i1.png",
+      },
+    });
+  });
+
+  test("createOBZ → path-collision names the colliding path", async () => {
+    const resources = new Map([["manifest.json", new Uint8Array([1])]]);
+
+    await expect(createOBZ([board()], "b", resources)).rejects.toMatchObject({
+      info: { code: "path-collision", path: "manifest.json" },
+    });
+  });
+});

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -4,6 +4,7 @@ import type { OBFErrorInfo } from "./errors";
 import { createOBZ, extractOBZ, parseManifest } from "./obz";
 import { parseOBF, validateOBF } from "./obf";
 import type { OBFBoard } from "./schema";
+import { expectOBFError, expectOBFErrorAsync } from "./test-utils";
 
 const board = (overrides: Partial<OBFBoard> = {}): OBFBoard => ({
   format: "open-board-0.1",
@@ -84,61 +85,48 @@ describe("OBFError", () => {
 
 describe("thrown OBFError.info across the surface", () => {
   test("parseOBF → not-json on malformed JSON", () => {
-    let info: OBFErrorInfo | undefined;
-    try {
-      parseOBF("{ not json ");
-    } catch (error) {
-      info = (error as OBFError).info;
-    }
+    const info = expectOBFError(() => parseOBF("{ not json "));
 
     expect(info).toMatchObject({ code: "not-json", source: "board" });
   });
 
   test("validateOBF → invalid-board carries non-empty issues", () => {
-    let error: OBFError | undefined;
-    try {
-      validateOBF({ id: "x" });
-    } catch (caught) {
-      error = caught as OBFError;
-    }
+    const info = expectOBFError(() => validateOBF({ id: "x" }));
 
-    expect(error?.info.code).toBe("invalid-board");
-    if (error?.info.code === "invalid-board") {
-      expect(error.info.issues.length).toBeGreaterThan(0);
-      expect(error.info.issues[0]).toHaveProperty("message");
+    expect(info.code).toBe("invalid-board");
+    if (info.code === "invalid-board") {
+      expect(info.issues.length).toBeGreaterThan(0);
+      expect(info.issues[0]).toHaveProperty("message");
     }
   });
 
   test("parseManifest → invalid-manifest carries issues", () => {
-    let error: OBFError | undefined;
-    try {
-      parseManifest(JSON.stringify({ format: "nope" }));
-    } catch (caught) {
-      error = caught as OBFError;
-    }
+    const info = expectOBFError(() =>
+      parseManifest(JSON.stringify({ format: "nope" })),
+    );
 
-    expect(error?.info.code).toBe("invalid-manifest");
-    if (error?.info.code === "invalid-manifest") {
-      expect(error.info.issues.length).toBeGreaterThan(0);
+    expect(info.code).toBe("invalid-manifest");
+    if (info.code === "invalid-manifest") {
+      expect(info.issues.length).toBeGreaterThan(0);
     }
   });
 
   test("extractOBZ → not-zip for non-archive bytes", async () => {
-    await expect(extractOBZ(new ArrayBuffer(4))).rejects.toMatchObject({
-      info: { code: "not-zip" },
-    });
+    expect(
+      (await expectOBFErrorAsync(extractOBZ(new ArrayBuffer(4)))).code,
+    ).toBe("not-zip");
   });
 
   test("createOBZ → unknown-root names the offending id", async () => {
-    await expect(createOBZ([board()], "missing")).rejects.toMatchObject({
-      info: { code: "unknown-root", rootBoardId: "missing" },
-    });
+    expect(
+      await expectOBFErrorAsync(createOBZ([board()], "missing")),
+    ).toMatchObject({ code: "unknown-root", rootBoardId: "missing" });
   });
 
   test("createOBZ → duplicate-board names the repeated id", async () => {
-    await expect(createOBZ([board(), board()], "b")).rejects.toMatchObject({
-      info: { code: "duplicate-board", boardId: "b" },
-    });
+    expect(
+      await expectOBFErrorAsync(createOBZ([board(), board()], "b")),
+    ).toMatchObject({ code: "duplicate-board", boardId: "b" });
   });
 
   test("createOBZ → missing-resource names kind, id, and path", async () => {
@@ -146,21 +134,21 @@ describe("thrown OBFError.info across the surface", () => {
       images: [{ id: "i1", path: "images/i1.png" }],
     });
 
-    await expect(createOBZ([withImage], "b")).rejects.toMatchObject({
-      info: {
-        code: "missing-resource",
-        kind: "image",
-        mediaId: "i1",
-        path: "images/i1.png",
-      },
+    expect(
+      await expectOBFErrorAsync(createOBZ([withImage], "b")),
+    ).toMatchObject({
+      code: "missing-resource",
+      kind: "image",
+      mediaId: "i1",
+      path: "images/i1.png",
     });
   });
 
   test("createOBZ → path-collision names the colliding path", async () => {
     const resources = new Map([["manifest.json", new Uint8Array([1])]]);
 
-    await expect(createOBZ([board()], "b", resources)).rejects.toMatchObject({
-      info: { code: "path-collision", path: "manifest.json" },
-    });
+    expect(
+      await expectOBFErrorAsync(createOBZ([board()], "b", resources)),
+    ).toMatchObject({ code: "path-collision", path: "manifest.json" });
   });
 });

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -43,29 +43,39 @@ describe("OBFError", () => {
     expect(error.message.length).toBeGreaterThan(0);
   });
 
-  test("threads `cause` for variants that carry one", () => {
+  test("threads `cause` from constructor options", () => {
     const root = new SyntaxError("boom");
-    const error = new OBFError({
-      code: "not-json",
-      source: "board",
-      cause: root,
-    });
+    const error = new OBFError(
+      { code: "not-json", source: "board" },
+      { cause: root },
+    );
 
     expect(error.cause).toBe(root);
   });
 
-  test("omits `cause` for variants that have none", () => {
+  test("omits `cause` when no options are passed", () => {
     expect(new OBFError({ code: "not-zip" }).cause).toBeUndefined();
   });
 
   test("derives a non-empty message for the zip-failed variant", () => {
-    const error = new OBFError({
-      code: "zip-failed",
-      cause: new Error("boom"),
-    });
+    const error = new OBFError(
+      { code: "zip-failed" },
+      { cause: new Error("boom") },
+    );
 
     expect(error.info.code).toBe("zip-failed");
     expect(error.message).toContain("ZIP archive");
+    expect(error.cause).toBeInstanceOf(Error);
+  });
+
+  test("derives a message for the internal variant from its detail", () => {
+    const error = new OBFError(
+      { code: "internal", detail: "generated manifest failed validation" },
+      { cause: new Error("boom") },
+    );
+
+    expect(error.info.code).toBe("internal");
+    expect(error.message).toContain("generated manifest failed validation");
     expect(error.cause).toBeInstanceOf(Error);
   });
 
@@ -109,6 +119,12 @@ describe("thrown OBFError.info across the surface", () => {
     if (info.code === "invalid-manifest") {
       expect(info.issues.length).toBeGreaterThan(0);
     }
+  });
+
+  test("parseManifest → not-json on malformed JSON", () => {
+    const info = expectOBFError(() => parseManifest("{ not json "));
+
+    expect(info).toMatchObject({ code: "not-json", source: "manifest" });
   });
 
   test("extractOBZ → not-zip for non-archive bytes", async () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,156 @@
+/**
+ * Typed errors for `@shayc/open-board-format`.
+ *
+ * Every failure thrown by this package is an {@link OBFError} carrying a
+ * discriminated {@link OBFErrorInfo} on its `info` property. Switch on
+ * `error.info.code` to get exactly the structured context for that failure —
+ * the human-readable `message` is derived from `info` and is not part of the
+ * stable contract.
+ *
+ * ```ts
+ * try {
+ *   await loadBoard(file);
+ * } catch (error) {
+ *   if (!(error instanceof OBFError)) throw error;
+ *   switch (error.info.code) {
+ *     case "missing-resource":
+ *       reupload(error.info.kind, error.info.path); // both fully typed
+ *       break;
+ *     case "invalid-board":
+ *       showIssues(error.info.issues);
+ *       break;
+ *   }
+ * }
+ * ```
+ */
+
+import { z } from "zod";
+
+/**
+ * A single schema validation problem — Zod's issue shape, re-exported under a
+ * stable name so consumers never reference Zod's `$`-prefixed core type.
+ */
+export type OBFIssue = z.core.$ZodIssue;
+
+/**
+ * Discriminated description of why an {@link OBFError} was thrown.
+ *
+ * Switch on `code`; each variant carries exactly the fields relevant to it,
+ * so there are no "present sometimes" optionals to guess about.
+ */
+export type OBFErrorInfo =
+  // --- decoding ---
+  /** Input was not parseable JSON. The underlying parse error is in `cause`. */
+  | { code: "not-json"; source: "board" | "manifest"; cause: unknown }
+  /** An OBZ archive was expected, but the bytes are not a ZIP. */
+  | { code: "not-zip" }
+  /** A ZIP archive could not be decompressed. */
+  | { code: "unreadable-zip"; cause: unknown }
+  // --- validation ---
+  /** A board failed schema validation. `boardId` is set when known. */
+  | {
+      code: "invalid-board";
+      boardId?: string;
+      issues: readonly OBFIssue[];
+      cause: z.ZodError;
+    }
+  /** A manifest failed schema validation. */
+  | { code: "invalid-manifest"; issues: readonly OBFIssue[]; cause: z.ZodError }
+  // --- archive structure (reading an .obz) ---
+  /** The archive has no `manifest.json`. */
+  | { code: "missing-manifest" }
+  /** A board the manifest declares is absent from the archive. */
+  | { code: "missing-board"; boardId: string; path: string }
+  /** A board's `id` disagrees with the id the manifest declares for it. */
+  | {
+      code: "board-id-mismatch";
+      path: string;
+      declaredId: string;
+      actualId: string;
+    }
+  // --- archive assembly (createOBZ) ---
+  /** `rootBoardId` matches none of the supplied boards. */
+  | { code: "unknown-root"; rootBoardId: string }
+  /** Two supplied boards share the same `id`. */
+  | { code: "duplicate-board"; boardId: string }
+  /** A board declares a media `path` with no matching resource. */
+  | {
+      code: "missing-resource";
+      kind: "image" | "sound";
+      mediaId: string;
+      path: string;
+    }
+  /** Two boards declare the same media id with different paths. */
+  | {
+      code: "conflicting-paths";
+      kind: "image" | "sound";
+      mediaId: string;
+      paths: [string, string];
+    }
+  /** A supplied resource would overwrite a generated board or the manifest. */
+  | { code: "path-collision"; path: string }
+  /** The archive could not be compressed. */
+  | { code: "zip-failed"; cause: unknown };
+
+/** Every `code` an {@link OBFError} can carry. */
+export type OBFErrorCode = OBFErrorInfo["code"];
+
+/**
+ * The single error type thrown by `@shayc/open-board-format`.
+ *
+ * Branch on {@link OBFError.info} (a discriminated {@link OBFErrorInfo}) rather
+ * than parsing {@link OBFError.message}.
+ */
+export class OBFError extends Error {
+  /** Structured, discriminated description of the failure. */
+  readonly info: OBFErrorInfo;
+
+  constructor(info: OBFErrorInfo) {
+    super(
+      formatOBFError(info),
+      "cause" in info ? { cause: info.cause } : undefined,
+    );
+    this.name = "OBFError";
+    this.info = info;
+  }
+}
+
+/** Derive a human-readable message from an {@link OBFErrorInfo}. */
+function formatOBFError(info: OBFErrorInfo): string {
+  switch (info.code) {
+    case "not-json":
+      return `Invalid ${info.source === "manifest" ? "OBZ manifest" : "OBF"}: not valid JSON`;
+    case "not-zip":
+      return "Invalid OBZ: not a ZIP file";
+    case "unreadable-zip":
+      return "ZIP archive could not be read";
+    case "invalid-board":
+      return `Invalid OBF${info.boardId ? ` board "${info.boardId}"` : " board"}:\n${z.prettifyError(info.cause)}`;
+    case "invalid-manifest":
+      return `Invalid OBZ manifest:\n${z.prettifyError(info.cause)}`;
+    case "missing-manifest":
+      return "Invalid OBZ: missing manifest.json";
+    case "missing-board":
+      return `Invalid OBZ: board "${info.boardId}" is declared in the manifest but missing at "${info.path}"`;
+    case "board-id-mismatch":
+      return `Invalid OBZ: board at "${info.path}" has id "${info.actualId}" but the manifest declares it as "${info.declaredId}"`;
+    case "unknown-root":
+      return `Invalid OBZ: rootBoardId "${info.rootBoardId}" does not match any supplied board`;
+    case "duplicate-board":
+      return `Invalid OBZ: duplicate board id "${info.boardId}" — board ids must be unique within a package`;
+    case "missing-resource":
+      return `Invalid OBZ: ${info.kind} "${info.mediaId}" references "${info.path}" but no matching resource was supplied`;
+    case "conflicting-paths":
+      return `Invalid OBZ: ${info.kind} id "${info.mediaId}" maps to conflicting paths "${info.paths[0]}" and "${info.paths[1]}"`;
+    case "path-collision":
+      return `Invalid OBZ: resource path "${info.path}" collides with a generated board or manifest entry`;
+    case "zip-failed":
+      return "Failed to build ZIP archive";
+    /* v8 ignore start -- exhaustiveness guard: unreachable, enforced at compile time */
+    default: {
+      const _exhaustive: never = info;
+      return _exhaustive;
+    }
+    /* v8 ignore stop */
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -35,27 +35,24 @@ export type OBFIssue = z.core.$ZodIssue;
 /**
  * Discriminated description of why an {@link OBFError} was thrown.
  *
- * Switch on `code`; each variant carries exactly the fields relevant to it,
- * so there are no "present sometimes" optionals to guess about.
+ * Switch on `code`; each variant carries the fields relevant to it. When a
+ * failure wraps an underlying error it lives on the standard `error.cause`,
+ * never duplicated here. The only optional field is `invalid-board`'s
+ * `boardId`, absent when validation runs on a value with no known id.
  */
 export type OBFErrorInfo =
-  // --- decoding ---
-  /** Input was not parseable JSON. The underlying parse error is in `cause`. */
-  | { code: "not-json"; source: "board" | "manifest"; cause: unknown }
+  // --- decoding (underlying parser/decompressor error on `error.cause`) ---
+  /** Input was not parseable JSON. */
+  | { code: "not-json"; source: "board" | "manifest" }
   /** An OBZ archive was expected, but the bytes are not a ZIP. */
   | { code: "not-zip" }
   /** A ZIP archive could not be decompressed. */
-  | { code: "unreadable-zip"; cause: unknown }
-  // --- validation ---
+  | { code: "unreadable-zip" }
+  // --- validation (underlying `ZodError` on `error.cause`) ---
   /** A board failed schema validation. `boardId` is set when known. */
-  | {
-      code: "invalid-board";
-      boardId?: string;
-      issues: readonly OBFIssue[];
-      cause: z.ZodError;
-    }
+  | { code: "invalid-board"; boardId?: string; issues: readonly OBFIssue[] }
   /** A manifest failed schema validation. */
-  | { code: "invalid-manifest"; issues: readonly OBFIssue[]; cause: z.ZodError }
+  | { code: "invalid-manifest"; issues: readonly OBFIssue[] }
   // --- archive structure (reading an .obz) ---
   /** The archive has no `manifest.json`. */
   | { code: "missing-manifest" }
@@ -90,7 +87,9 @@ export type OBFErrorInfo =
   /** A supplied resource would overwrite a generated board or the manifest. */
   | { code: "path-collision"; path: string }
   /** The archive could not be compressed. */
-  | { code: "zip-failed"; cause: unknown };
+  | { code: "zip-failed" }
+  /** An internal invariant was violated — a bug in this library; please report. */
+  | { code: "internal"; detail: string };
 
 /** Every `code` an {@link OBFError} can carry. */
 export type OBFErrorCode = OBFErrorInfo["code"];
@@ -99,17 +98,15 @@ export type OBFErrorCode = OBFErrorInfo["code"];
  * The single error type thrown by `@shayc/open-board-format`.
  *
  * Branch on {@link OBFError.info} (a discriminated {@link OBFErrorInfo}) rather
- * than parsing {@link OBFError.message}.
+ * than parsing {@link OBFError.message}. Any underlying error — a `JSON.parse`
+ * failure, a `ZodError`, or an fflate error — is on the standard `error.cause`.
  */
 export class OBFError extends Error {
   /** Structured, discriminated description of the failure. */
   readonly info: OBFErrorInfo;
 
-  constructor(info: OBFErrorInfo) {
-    super(
-      formatOBFError(info),
-      "cause" in info ? { cause: info.cause } : undefined,
-    );
+  constructor(info: OBFErrorInfo, options?: { cause?: unknown }) {
+    super(formatOBFError(info), options);
     this.name = "OBFError";
     this.info = info;
   }
@@ -125,9 +122,9 @@ function formatOBFError(info: OBFErrorInfo): string {
     case "unreadable-zip":
       return "ZIP archive could not be read";
     case "invalid-board":
-      return `Invalid OBF${info.boardId ? ` board "${info.boardId}"` : " board"}:\n${z.prettifyError(info.cause)}`;
+      return `Invalid OBF${info.boardId ? ` board "${info.boardId}"` : " board"}:\n${prettifyIssues(info.issues)}`;
     case "invalid-manifest":
-      return `Invalid OBZ manifest:\n${z.prettifyError(info.cause)}`;
+      return `Invalid OBZ manifest:\n${prettifyIssues(info.issues)}`;
     case "missing-manifest":
       return "Invalid OBZ: missing manifest.json";
     case "missing-board":
@@ -146,6 +143,8 @@ function formatOBFError(info: OBFErrorInfo): string {
       return `Invalid OBZ: resource path "${info.path}" collides with a generated board or manifest entry`;
     case "zip-failed":
       return "Failed to build ZIP archive";
+    case "internal":
+      return `Internal error (please report): ${info.detail}`;
     /* v8 ignore start -- exhaustiveness guard: unreachable, enforced at compile time */
     default: {
       const _exhaustive: never = info;
@@ -153,4 +152,9 @@ function formatOBFError(info: OBFErrorInfo): string {
     }
     /* v8 ignore stop */
   }
+}
+
+/** Render schema issues using Zod's pretty formatter. */
+function prettifyIssues(issues: readonly OBFIssue[]): string {
+  return z.prettifyError(new z.ZodError([...issues]));
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -28,7 +28,9 @@ import { z } from "zod";
 
 /**
  * A single schema validation problem — Zod's issue shape, re-exported under a
- * stable name so consumers never reference Zod's `$`-prefixed core type.
+ * domain name. `z.core.$ZodIssue` is the type Zod v4 designates for libraries
+ * built on it (the bare `z.ZodIssue` is deprecated in its favor); aliasing it
+ * gives consumers a stable OBF name without reaching into Zod's `core` export.
  */
 export type OBFIssue = z.core.$ZodIssue;
 
@@ -121,8 +123,10 @@ function formatOBFError(info: OBFErrorInfo): string {
       return "Invalid OBZ: not a ZIP file";
     case "unreadable-zip":
       return "ZIP archive could not be read";
-    case "invalid-board":
-      return `Invalid OBF${info.boardId ? ` board "${info.boardId}"` : " board"}:\n${prettifyIssues(info.issues)}`;
+    case "invalid-board": {
+      const subject = info.boardId ? `board "${info.boardId}"` : "board";
+      return `Invalid OBF ${subject}:\n${prettifyIssues(info.issues)}`;
+    }
     case "invalid-manifest":
       return `Invalid OBZ manifest:\n${prettifyIssues(info.issues)}`;
     case "missing-manifest":

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,17 +45,19 @@ export {
   OBFSymbolInfoSchema,
 } from "./schema";
 
+// Typed errors thrown across the package
+export { OBFError } from "./errors";
+export type { OBFErrorCode, OBFErrorInfo, OBFIssue } from "./errors";
+
 // Single-board (.obf) parsing, validation, and serialization
 export { loadOBF, parseOBF, stringifyOBF, validateOBF } from "./obf";
 
 // Board-package (.obz) creation and extraction
 export { createOBZ, extractOBZ, loadOBZ, parseManifest } from "./obz";
-
 export type { ParsedOBZ } from "./obz";
 
 // Format-agnostic loading of .obf or .obz input
 export { loadBoard } from "./load-board";
-
 export type { LoadedBoard } from "./load-board";
 
 // ZIP helpers

--- a/src/load-board.test.ts
+++ b/src/load-board.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from "vitest";
 import { loadBoard } from "./load-board";
 import { createOBZ } from "./obz";
 import type { OBFBoard } from "./schema";
+import { expectOBFErrorAsync } from "./test-utils";
 import { zip } from "./zip";
 
 const validBoard: OBFBoard = {
@@ -79,7 +80,7 @@ describe("loadBoard", () => {
   test("surfaces the OBF parser's error for a non-ZIP malformed board", async () => {
     const file = new File(['{ "format": "open-board-0.1", }'], "bad.obf");
 
-    await expect(loadBoard(file)).rejects.toThrow(/Invalid OBF/);
+    expect((await expectOBFErrorAsync(loadBoard(file))).code).toBe("not-json");
   });
 
   test("surfaces the OBZ extractor's error for a ZIP missing its manifest", async () => {
@@ -89,8 +90,8 @@ describe("loadBoard", () => {
     );
     const file = new File([zipped], "no-manifest.obz");
 
-    await expect(loadBoard(file)).rejects.toThrow(
-      /Invalid OBZ: missing manifest\.json/,
+    expect((await expectOBFErrorAsync(loadBoard(file))).code).toBe(
+      "missing-manifest",
     );
   });
 });

--- a/src/load-board.ts
+++ b/src/load-board.ts
@@ -40,8 +40,9 @@ export type LoadedBoard =
  * @param input - A `File` handle or `ArrayBuffer` holding `.obf` or `.obz` content.
  * @returns A discriminated union tagged by `format`.
  *
- * @throws {Error} If an OBZ archive is malformed or its manifest is missing,
- *   or if an OBF board is malformed or fails schema validation.
+ * @throws {@link OBFError} — the OBZ failures of {@link extractOBZ} when the
+ *   input is an archive, or the OBF failures of {@link parseOBF} otherwise.
+ *   Branch on `error.info.code`.
  */
 export async function loadBoard(
   input: File | ArrayBuffer,

--- a/src/obf.test.ts
+++ b/src/obf.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
-import { OBFError } from "./errors";
 import { loadOBF, parseOBF, stringifyOBF, validateOBF } from "./obf";
 import type { OBFBoard } from "./schema";
+import { expectOBFError } from "./test-utils";
 
 const validBoard: OBFBoard = {
   format: "open-board-0.1",
@@ -21,21 +21,14 @@ describe("parseOBF", () => {
   });
 
   test("throws a not-json OBFError for invalid JSON, preserving the cause", () => {
-    const malformedJson = '{ "format": "open-board-0.1", }';
+    const info = expectOBFError(() =>
+      parseOBF('{ "format": "open-board-0.1", }'),
+    );
 
-    let thrown: unknown;
-    try {
-      parseOBF(malformedJson);
-    } catch (error) {
-      thrown = error;
+    expect(info).toMatchObject({ code: "not-json", source: "board" });
+    if (info.code === "not-json") {
+      expect(info.cause).toBeInstanceOf(Error);
     }
-
-    expect(thrown).toBeInstanceOf(OBFError);
-    expect((thrown as OBFError).info).toMatchObject({
-      code: "not-json",
-      source: "board",
-    });
-    expect((thrown as OBFError).cause).toBeInstanceOf(Error);
   });
 
   test("handles UTF-8 BOM prefix", () => {
@@ -58,7 +51,9 @@ describe("validateOBF", () => {
       buttons: [],
     };
 
-    expect(() => validateOBF(boardWithoutGrid)).toThrow(/Invalid OBF/);
+    expect(expectOBFError(() => validateOBF(boardWithoutGrid)).code).toBe(
+      "invalid-board",
+    );
   });
 });
 

--- a/src/obf.test.ts
+++ b/src/obf.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { OBFError } from "./errors";
 import { loadOBF, parseOBF, stringifyOBF, validateOBF } from "./obf";
 import type { OBFBoard } from "./schema";
 import { expectOBFError } from "./test-utils";
@@ -21,14 +22,19 @@ describe("parseOBF", () => {
   });
 
   test("throws a not-json OBFError for invalid JSON, preserving the cause", () => {
-    const info = expectOBFError(() =>
-      parseOBF('{ "format": "open-board-0.1", }'),
-    );
-
-    expect(info).toMatchObject({ code: "not-json", source: "board" });
-    if (info.code === "not-json") {
-      expect(info.cause).toBeInstanceOf(Error);
+    let thrown: unknown;
+    try {
+      parseOBF('{ "format": "open-board-0.1", }');
+    } catch (error) {
+      thrown = error;
     }
+
+    expect(thrown).toBeInstanceOf(OBFError);
+    expect((thrown as OBFError).info).toMatchObject({
+      code: "not-json",
+      source: "board",
+    });
+    expect((thrown as OBFError).cause).toBeInstanceOf(SyntaxError);
   });
 
   test("handles UTF-8 BOM prefix", () => {

--- a/src/obf.test.ts
+++ b/src/obf.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { OBFError } from "./errors";
 import { loadOBF, parseOBF, stringifyOBF, validateOBF } from "./obf";
 import type { OBFBoard } from "./schema";
 
@@ -19,12 +20,22 @@ describe("parseOBF", () => {
     expect(result).toEqual(validBoard);
   });
 
-  test("throws descriptive error for invalid JSON", () => {
+  test("throws a not-json OBFError for invalid JSON, preserving the cause", () => {
     const malformedJson = '{ "format": "open-board-0.1", }';
 
-    expect(() => parseOBF(malformedJson)).toThrow(
-      /Invalid OBF: JSON parse failed/,
-    );
+    let thrown: unknown;
+    try {
+      parseOBF(malformedJson);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(OBFError);
+    expect((thrown as OBFError).info).toMatchObject({
+      code: "not-json",
+      source: "board",
+    });
+    expect((thrown as OBFError).cause).toBeInstanceOf(Error);
   });
 
   test("handles UTF-8 BOM prefix", () => {

--- a/src/obf.ts
+++ b/src/obf.ts
@@ -33,7 +33,7 @@ export function parseOBF(json: string): OBFBoard {
   try {
     rawBoard = JSON.parse(sanitized) as unknown;
   } catch (error) {
-    throw new OBFError({ code: "not-json", source: "board", cause: error });
+    throw new OBFError({ code: "not-json", source: "board" }, { cause: error });
   }
 
   return validateOBF(rawBoard);
@@ -69,11 +69,10 @@ export function validateOBF(data: unknown): OBFBoard {
   const result = OBFBoardSchema.safeParse(data);
 
   if (!result.success) {
-    throw new OBFError({
-      code: "invalid-board",
-      issues: result.error.issues,
-      cause: result.error,
-    });
+    throw new OBFError(
+      { code: "invalid-board", issues: result.error.issues },
+      { cause: result.error },
+    );
   }
 
   return result.data;

--- a/src/obf.ts
+++ b/src/obf.ts
@@ -2,6 +2,7 @@
  * Parsing, validation, and serialization for single `.obf` board files.
  */
 
+import { OBFError } from "./errors";
 import type { OBFBoard } from "./schema";
 import { OBFBoardSchema } from "./schema";
 
@@ -13,22 +14,6 @@ function stripBom(text: string): string {
 }
 
 /**
- * Build a descriptive JSON parse-failure message, preserving the engine's
- * reason when available.
- *
- * @internal Exported for reuse by the OBZ module — not part of the public API.
- */
-export function buildJsonParseErrorMessage(
-  label: string,
-  error: unknown,
-): string {
-  const reason = error instanceof Error ? error.message : "";
-  return reason
-    ? `Invalid ${label}: JSON parse failed — ${reason}`
-    : `Invalid ${label}: JSON parse failed`;
-}
-
-/**
  * Parse a JSON string into a validated OBF board.
  *
  * Strips an optional UTF-8 BOM prefix before parsing and throws a
@@ -37,7 +22,8 @@ export function buildJsonParseErrorMessage(
  * @param json - The JSON string to parse.
  * @returns The validated board object.
  *
- * @throws {Error} If the JSON is malformed or fails schema validation.
+ * @throws {@link OBFError} with `info.code` `"not-json"` if the JSON is
+ *   malformed, or `"invalid-board"` if it fails schema validation.
  */
 export function parseOBF(json: string): OBFBoard {
   const sanitized = stripBom(json);
@@ -47,7 +33,7 @@ export function parseOBF(json: string): OBFBoard {
   try {
     rawBoard = JSON.parse(sanitized) as unknown;
   } catch (error) {
-    throw new Error(buildJsonParseErrorMessage("OBF", error), { cause: error });
+    throw new OBFError({ code: "not-json", source: "board", cause: error });
   }
 
   return validateOBF(rawBoard);
@@ -62,7 +48,8 @@ export function parseOBF(json: string): OBFBoard {
  * @param file - A `File` handle pointing to an `.obf` file.
  * @returns The validated board object.
  *
- * @throws {Error} If the file content is malformed or fails schema validation.
+ * @throws {@link OBFError} with `info.code` `"not-json"` if the file content is
+ *   malformed, or `"invalid-board"` if it fails schema validation.
  */
 export async function loadOBF(file: File): Promise<OBFBoard> {
   const json = await file.text();
@@ -75,13 +62,18 @@ export async function loadOBF(file: File): Promise<OBFBoard> {
  * @param data - The value to validate.
  * @returns The validated board object.
  *
- * @throws {Error} If the value fails schema validation.
+ * @throws {@link OBFError} with `info.code` `"invalid-board"` if the value fails
+ *   schema validation. `info.issues` holds the underlying Zod issues.
  */
 export function validateOBF(data: unknown): OBFBoard {
   const result = OBFBoardSchema.safeParse(data);
 
   if (!result.success) {
-    throw new Error(`Invalid OBF: ${result.error.message}`);
+    throw new OBFError({
+      code: "invalid-board",
+      issues: result.error.issues,
+      cause: result.error,
+    });
   }
 
   return result.data;

--- a/src/obz.test.ts
+++ b/src/obz.test.ts
@@ -1,19 +1,8 @@
 import { describe, expect, test } from "vitest";
-import { OBFError } from "./errors";
 import { createOBZ, extractOBZ, loadOBZ, parseManifest } from "./obz";
 import type { OBFBoard } from "./schema";
+import { expectOBFError, expectOBFErrorAsync } from "./test-utils";
 import { zip } from "./zip";
-
-/** Run `fn`, assert it threw an `OBFError`, and return its `info` to inspect. */
-function caught(fn: () => unknown): OBFError["info"] {
-  try {
-    fn();
-  } catch (error) {
-    expect(error).toBeInstanceOf(OBFError);
-    return (error as OBFError).info;
-  }
-  throw new Error("expected an OBFError to be thrown");
-}
 
 describe("parseManifest", () => {
   test("parses valid manifest", () => {
@@ -37,7 +26,7 @@ describe("parseManifest", () => {
       paths: { boards: { test: "boards/test.obf" }, images: {} },
     });
 
-    expect(caught(() => parseManifest(invalidManifest)).code).toBe(
+    expect(expectOBFError(() => parseManifest(invalidManifest)).code).toBe(
       "invalid-manifest",
     );
   });
@@ -49,7 +38,7 @@ describe("parseManifest", () => {
       paths: { boards: { test: "boards/test.obf" }, images: {} },
     });
 
-    expect(caught(() => parseManifest(rootNotListed)).code).toBe(
+    expect(expectOBFError(() => parseManifest(rootNotListed)).code).toBe(
       "invalid-manifest",
     );
   });
@@ -82,8 +71,8 @@ describe("extractOBZ", () => {
   test("throws for non-ZIP input", async () => {
     const notZip = new ArrayBuffer(10);
 
-    await expect(extractOBZ(notZip)).rejects.toThrow(
-      "Invalid OBZ: not a ZIP file",
+    expect((await expectOBFErrorAsync(extractOBZ(notZip))).code).toBe(
+      "not-zip",
     );
   });
 
@@ -93,9 +82,10 @@ describe("extractOBZ", () => {
     ]);
     const zipBuffer = await zip(filesWithoutManifest);
 
-    await expect(extractOBZ(zipBuffer.buffer as ArrayBuffer)).rejects.toThrow(
-      "Invalid OBZ: missing manifest.json",
-    );
+    expect(
+      (await expectOBFErrorAsync(extractOBZ(zipBuffer.buffer as ArrayBuffer)))
+        .code,
+    ).toBe("missing-manifest");
   });
 
   test("throws when manifest references a missing board file", async () => {
@@ -109,14 +99,12 @@ describe("extractOBZ", () => {
     ]);
     const zipBuffer = await zip(filesWithMissingBoard);
 
-    await expect(
-      extractOBZ(zipBuffer.buffer as ArrayBuffer),
-    ).rejects.toMatchObject({
-      info: {
-        code: "missing-board",
-        boardId: "missing",
-        path: "boards/missing.obf",
-      },
+    expect(
+      await expectOBFErrorAsync(extractOBZ(zipBuffer.buffer as ArrayBuffer)),
+    ).toMatchObject({
+      code: "missing-board",
+      boardId: "missing",
+      path: "boards/missing.obf",
     });
   });
 
@@ -159,9 +147,14 @@ describe("extractOBZ", () => {
     ]);
     const zipBuffer = await zip(files);
 
-    await expect(extractOBZ(zipBuffer.buffer as ArrayBuffer)).rejects.toThrow(
-      'Invalid OBZ: board at "boards/home.obf" has id "home" but the manifest declares it as "1"',
-    );
+    expect(
+      await expectOBFErrorAsync(extractOBZ(zipBuffer.buffer as ArrayBuffer)),
+    ).toMatchObject({
+      code: "board-id-mismatch",
+      path: "boards/home.obf",
+      declaredId: "1",
+      actualId: "home",
+    });
   });
 
   test("throws when two manifest keys map to the same board file", async () => {
@@ -182,9 +175,14 @@ describe("extractOBZ", () => {
     ]);
     const zipBuffer = await zip(files);
 
-    await expect(extractOBZ(zipBuffer.buffer as ArrayBuffer)).rejects.toThrow(
-      'Invalid OBZ: board at "boards/a.obf" has id "a" but the manifest declares it as "b"',
-    );
+    expect(
+      await expectOBFErrorAsync(extractOBZ(zipBuffer.buffer as ArrayBuffer)),
+    ).toMatchObject({
+      code: "board-id-mismatch",
+      path: "boards/a.obf",
+      declaredId: "b",
+      actualId: "a",
+    });
   });
 });
 
@@ -233,9 +231,9 @@ describe("createOBZ", () => {
       grid: { rows: 1, columns: 1, order: [[null]] },
     };
 
-    await expect(createOBZ([board], "wrong-id")).rejects.toThrow(
-      /rootBoardId "wrong-id" does not match/,
-    );
+    expect(
+      await expectOBFErrorAsync(createOBZ([board], "wrong-id")),
+    ).toMatchObject({ code: "unknown-root", rootBoardId: "wrong-id" });
   });
 
   test("throws when two boards share the same id", async () => {
@@ -246,9 +244,9 @@ describe("createOBZ", () => {
       grid: { rows: 1, columns: 1, order: [[null]] },
     });
 
-    await expect(createOBZ([makeBoard(), makeBoard()], "dup")).rejects.toThrow(
-      /duplicate board id "dup"/,
-    );
+    expect(
+      await expectOBFErrorAsync(createOBZ([makeBoard(), makeBoard()], "dup")),
+    ).toMatchObject({ code: "duplicate-board", boardId: "dup" });
   });
 
   test("throws when a supplied board fails schema validation", async () => {
@@ -259,9 +257,9 @@ describe("createOBZ", () => {
       // grid is required by OBFBoardSchema
     } as unknown as OBFBoard;
 
-    await expect(createOBZ([invalidBoard], "bad")).rejects.toMatchObject({
-      info: { code: "invalid-board", boardId: "bad" },
-    });
+    expect(
+      await expectOBFErrorAsync(createOBZ([invalidBoard], "bad")),
+    ).toMatchObject({ code: "invalid-board", boardId: "bad" });
   });
 
   test("populates manifest.paths.images from board image entries", async () => {
@@ -307,9 +305,12 @@ describe("createOBZ", () => {
       images: [{ id: "i1", path: "images/i1.png" }],
     };
 
-    await expect(createOBZ([board], "b")).rejects.toThrow(
-      /image "i1" references "images\/i1\.png" but no matching resource/,
-    );
+    expect(await expectOBFErrorAsync(createOBZ([board], "b"))).toMatchObject({
+      code: "missing-resource",
+      kind: "image",
+      mediaId: "i1",
+      path: "images/i1.png",
+    });
   });
 
   test("throws when a board sound path has no matching resource", async () => {
@@ -321,9 +322,12 @@ describe("createOBZ", () => {
       sounds: [{ id: "s1", path: "sounds/s1.mp3" }],
     };
 
-    await expect(createOBZ([board], "b")).rejects.toThrow(
-      /sound "s1" references "sounds\/s1\.mp3" but no matching resource/,
-    );
+    expect(await expectOBFErrorAsync(createOBZ([board], "b"))).toMatchObject({
+      code: "missing-resource",
+      kind: "sound",
+      mediaId: "s1",
+      path: "sounds/s1.mp3",
+    });
   });
 
   test("throws when a resource collides with the generated manifest", async () => {
@@ -335,9 +339,9 @@ describe("createOBZ", () => {
     };
     const resources = new Map([["manifest.json", new Uint8Array([1])]]);
 
-    await expect(createOBZ([board], "b", resources)).rejects.toThrow(
-      /resource path "manifest\.json" collides with a generated/,
-    );
+    expect(
+      await expectOBFErrorAsync(createOBZ([board], "b", resources)),
+    ).toMatchObject({ code: "path-collision", path: "manifest.json" });
   });
 
   test("throws when a resource collides with a generated board file", async () => {
@@ -349,9 +353,9 @@ describe("createOBZ", () => {
     };
     const resources = new Map([["boards/b.obf", new Uint8Array([1])]]);
 
-    await expect(createOBZ([board], "b", resources)).rejects.toThrow(
-      /resource path "boards\/b\.obf" collides with a generated/,
-    );
+    expect(
+      await expectOBFErrorAsync(createOBZ([board], "b", resources)),
+    ).toMatchObject({ code: "path-collision", path: "boards/b.obf" });
   });
 
   test("omits sounds map when no sounds have paths", async () => {
@@ -386,13 +390,13 @@ describe("createOBZ", () => {
       images: [{ id: "shared", path: "images/b.png" }],
     };
 
-    await expect(createOBZ([board1, board2], "b1")).rejects.toMatchObject({
-      info: {
-        code: "conflicting-paths",
-        kind: "image",
-        mediaId: "shared",
-        paths: ["images/a.png", "images/b.png"],
-      },
+    expect(
+      await expectOBFErrorAsync(createOBZ([board1, board2], "b1")),
+    ).toMatchObject({
+      code: "conflicting-paths",
+      kind: "image",
+      mediaId: "shared",
+      paths: ["images/a.png", "images/b.png"],
     });
   });
 });

--- a/src/obz.test.ts
+++ b/src/obz.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, test } from "vitest";
+import { OBFError } from "./errors";
 import { createOBZ, extractOBZ, loadOBZ, parseManifest } from "./obz";
 import type { OBFBoard } from "./schema";
 import { zip } from "./zip";
+
+/** Run `fn`, assert it threw an `OBFError`, and return its `info` to inspect. */
+function caught(fn: () => unknown): OBFError["info"] {
+  try {
+    fn();
+  } catch (error) {
+    expect(error).toBeInstanceOf(OBFError);
+    return (error as OBFError).info;
+  }
+  throw new Error("expected an OBFError to be thrown");
+}
 
 describe("parseManifest", () => {
   test("parses valid manifest", () => {
@@ -25,7 +37,9 @@ describe("parseManifest", () => {
       paths: { boards: { test: "boards/test.obf" }, images: {} },
     });
 
-    expect(() => parseManifest(invalidManifest)).toThrow(/Invalid manifest/);
+    expect(caught(() => parseManifest(invalidManifest)).code).toBe(
+      "invalid-manifest",
+    );
   });
 
   test("throws when root is not listed in paths.boards", () => {
@@ -35,7 +49,9 @@ describe("parseManifest", () => {
       paths: { boards: { test: "boards/test.obf" }, images: {} },
     });
 
-    expect(() => parseManifest(rootNotListed)).toThrow(/Invalid manifest/);
+    expect(caught(() => parseManifest(rootNotListed)).code).toBe(
+      "invalid-manifest",
+    );
   });
 });
 
@@ -93,9 +109,15 @@ describe("extractOBZ", () => {
     ]);
     const zipBuffer = await zip(filesWithMissingBoard);
 
-    await expect(extractOBZ(zipBuffer.buffer as ArrayBuffer)).rejects.toThrow(
-      'Invalid OBZ: board "missing" declared in manifest but missing',
-    );
+    await expect(
+      extractOBZ(zipBuffer.buffer as ArrayBuffer),
+    ).rejects.toMatchObject({
+      info: {
+        code: "missing-board",
+        boardId: "missing",
+        path: "boards/missing.obf",
+      },
+    });
   });
 
   test("resolves rootBoard, including when root is not the first board", async () => {
@@ -237,9 +259,9 @@ describe("createOBZ", () => {
       // grid is required by OBFBoardSchema
     } as unknown as OBFBoard;
 
-    await expect(createOBZ([invalidBoard], "bad")).rejects.toThrow(
-      /Invalid OBZ: board "bad" failed validation/,
-    );
+    await expect(createOBZ([invalidBoard], "bad")).rejects.toMatchObject({
+      info: { code: "invalid-board", boardId: "bad" },
+    });
   });
 
   test("populates manifest.paths.images from board image entries", async () => {
@@ -364,9 +386,14 @@ describe("createOBZ", () => {
       images: [{ id: "shared", path: "images/b.png" }],
     };
 
-    await expect(createOBZ([board1, board2], "b1")).rejects.toThrow(
-      /images id "shared" maps to conflicting paths/,
-    );
+    await expect(createOBZ([board1, board2], "b1")).rejects.toMatchObject({
+      info: {
+        code: "conflicting-paths",
+        kind: "image",
+        mediaId: "shared",
+        paths: ["images/a.png", "images/b.png"],
+      },
+    });
   });
 });
 

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -88,17 +88,19 @@ export function parseManifest(json: string): OBFManifest {
   try {
     data = JSON.parse(json) as unknown;
   } catch (error) {
-    throw new OBFError({ code: "not-json", source: "manifest", cause: error });
+    throw new OBFError(
+      { code: "not-json", source: "manifest" },
+      { cause: error },
+    );
   }
 
   const result = OBFManifestSchema.safeParse(data);
 
   if (!result.success) {
-    throw new OBFError({
-      code: "invalid-manifest",
-      issues: result.error.issues,
-      cause: result.error,
-    });
+    throw new OBFError(
+      { code: "invalid-manifest", issues: result.error.issues },
+      { cause: result.error },
+    );
   }
 
   return result.data;
@@ -160,13 +162,14 @@ export async function createOBZ(
     },
   });
 
+  /* v8 ignore start -- defensive: the manifest is built from already-validated inputs */
   if (!manifestResult.success) {
-    throw new OBFError({
-      code: "invalid-manifest",
-      issues: manifestResult.error.issues,
-      cause: manifestResult.error,
-    });
+    throw new OBFError(
+      { code: "internal", detail: "generated manifest failed validation" },
+      { cause: manifestResult.error },
+    );
   }
+  /* v8 ignore stop */
 
   const manifest = manifestResult.data;
 
@@ -180,12 +183,14 @@ export async function createOBZ(
   for (const board of boards) {
     const result = OBFBoardSchema.safeParse(board);
     if (!result.success) {
-      throw new OBFError({
-        code: "invalid-board",
-        boardId: board.id,
-        issues: result.error.issues,
-        cause: result.error,
-      });
+      throw new OBFError(
+        {
+          code: "invalid-board",
+          boardId: board.id,
+          issues: result.error.issues,
+        },
+        { cause: result.error },
+      );
     }
     const path = `boards/${result.data.id}.obf`;
     entries.set(path, encoder.encode(JSON.stringify(result.data, null, 2)));
@@ -316,5 +321,14 @@ function extractBoards(
 
   // `OBFManifestSchema` requires `root` to be one of `paths.boards`, so the loop
   // above always assigns `rootBoard` for the validated manifests we receive.
-  return { boards, rootBoard: rootBoard! };
+  /* v8 ignore start -- defensive: OBFManifestSchema guarantees root ∈ paths.boards */
+  if (!rootBoard) {
+    throw new OBFError({
+      code: "internal",
+      detail: `root board "${manifest.root}" not found in paths.boards`,
+    });
+  }
+  /* v8 ignore stop */
+
+  return { boards, rootBoard };
 }

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -112,12 +112,12 @@ export function parseManifest(json: string): OBFManifest {
  * A manifest is generated automatically from the supplied boards,
  * using the `rootBoardId` to designate the entry-point board.
  *
+ * Every failure is an {@link OBFError}; branch on `info.code`.
+ *
  * @param boards - The boards to include in the archive.
  * @param rootBoardId - The ID of the board that serves as the archive's entry point.
  * @param resources - Optional map of file paths to binary content (images, sounds, etc.).
  * @returns A `Blob` containing the compressed OBZ archive.
- *
- * All failures are an {@link OBFError}; branch on `info.code`:
  *
  * @throws {@link OBFError} `"unknown-root"` if `rootBoardId` does not match any of the supplied boards.
  * @throws {@link OBFError} `"duplicate-board"` if two supplied boards share the same ID.

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -2,7 +2,8 @@
  * Creation and extraction of `.obz` board packages.
  */
 
-import { buildJsonParseErrorMessage, parseOBF } from "./obf";
+import { OBFError } from "./errors";
+import { parseOBF } from "./obf";
 import type { OBFBoard, OBFManifest } from "./schema";
 import { OBFBoardSchema, OBFManifestSchema } from "./schema";
 import { isZip, unzip, zip } from "./zip";
@@ -37,7 +38,8 @@ export interface ParsedOBZ {
  * @param file - A `File` handle pointing to an `.obz` archive.
  * @returns The parsed manifest, boards, root board, and binary resources.
  *
- * @throws {Error} Same failures as {@link extractOBZ}, which this delegates to.
+ * @throws {@link OBFError} — the same failures as {@link extractOBZ}, which
+ *   this delegates to.
  */
 export async function loadOBZ(file: File): Promise<ParsedOBZ> {
   const archive = await file.arrayBuffer();
@@ -52,13 +54,14 @@ export async function loadOBZ(file: File): Promise<ParsedOBZ> {
  *          the resolved root board, and a map of file paths to their
  *          binary content.
  *
- * @throws {Error} If the archive is not a valid ZIP, the manifest is missing,
- *   a board declared in the manifest is missing or fails validation, or a
- *   board's `id` differs from the ID the manifest declares for it.
+ * @throws {@link OBFError}; branch on `info.code`: `"not-zip"`,
+ *   `"unreadable-zip"`, `"missing-manifest"`, `"not-json"` or
+ *   `"invalid-manifest"` (bad manifest), `"missing-board"`,
+ *   `"board-id-mismatch"`, or `"invalid-board"` (a board fails validation).
  */
 export async function extractOBZ(archive: ArrayBuffer): Promise<ParsedOBZ> {
   if (!isZip(archive)) {
-    throw new Error("Invalid OBZ: not a ZIP file");
+    throw new OBFError({ code: "not-zip" });
   }
 
   const entries = await unzip(archive);
@@ -76,7 +79,8 @@ export async function extractOBZ(archive: ArrayBuffer): Promise<ParsedOBZ> {
  * @param json - A JSON string representing the manifest.
  * @returns The validated manifest object.
  *
- * @throws {Error} If the JSON is malformed or fails schema validation.
+ * @throws {@link OBFError} with `info.code` `"not-json"` if the JSON is
+ *   malformed, or `"invalid-manifest"` if it fails schema validation.
  */
 export function parseManifest(json: string): OBFManifest {
   let data: unknown;
@@ -84,15 +88,17 @@ export function parseManifest(json: string): OBFManifest {
   try {
     data = JSON.parse(json) as unknown;
   } catch (error) {
-    throw new Error(buildJsonParseErrorMessage("manifest", error), {
-      cause: error,
-    });
+    throw new OBFError({ code: "not-json", source: "manifest", cause: error });
   }
 
   const result = OBFManifestSchema.safeParse(data);
 
   if (!result.success) {
-    throw new Error(`Invalid manifest: ${result.error.message}`);
+    throw new OBFError({
+      code: "invalid-manifest",
+      issues: result.error.issues,
+      cause: result.error,
+    });
   }
 
   return result.data;
@@ -109,12 +115,14 @@ export function parseManifest(json: string): OBFManifest {
  * @param resources - Optional map of file paths to binary content (images, sounds, etc.).
  * @returns A `Blob` containing the compressed OBZ archive.
  *
- * @throws {Error} If `rootBoardId` does not match any of the supplied boards.
- * @throws {Error} If two supplied boards share the same ID.
- * @throws {Error} If a supplied board fails schema validation.
- * @throws {Error} If two boards declare the same media ID with conflicting paths.
- * @throws {Error} If a board declares an image or sound `path` with no matching entry in `resources`.
- * @throws {Error} If a `resources` entry would overwrite the generated `manifest.json` or a board file.
+ * All failures are an {@link OBFError}; branch on `info.code`:
+ *
+ * @throws {@link OBFError} `"unknown-root"` if `rootBoardId` does not match any of the supplied boards.
+ * @throws {@link OBFError} `"duplicate-board"` if two supplied boards share the same ID.
+ * @throws {@link OBFError} `"invalid-board"` if a supplied board fails schema validation.
+ * @throws {@link OBFError} `"conflicting-paths"` if two boards declare the same media ID with conflicting paths.
+ * @throws {@link OBFError} `"missing-resource"` if a board declares an image or sound `path` with no matching entry in `resources`.
+ * @throws {@link OBFError} `"path-collision"` if a `resources` entry would overwrite the generated `manifest.json` or a board file.
  */
 export async function createOBZ(
   boards: OBFBoard[],
@@ -122,17 +130,13 @@ export async function createOBZ(
   resources?: Map<string, Uint8Array | ArrayBuffer>,
 ): Promise<Blob> {
   if (!boards.some((board) => board.id === rootBoardId)) {
-    throw new Error(
-      `Invalid OBZ: rootBoardId "${rootBoardId}" does not match any supplied board`,
-    );
+    throw new OBFError({ code: "unknown-root", rootBoardId });
   }
 
   const seenBoardIds = new Set<string>();
   for (const board of boards) {
     if (seenBoardIds.has(board.id)) {
-      throw new Error(
-        `Invalid OBZ: duplicate board id "${board.id}" — board ids must be unique within a package`,
-      );
+      throw new OBFError({ code: "duplicate-board", boardId: board.id });
     }
     seenBoardIds.add(board.id);
   }
@@ -157,9 +161,11 @@ export async function createOBZ(
   });
 
   if (!manifestResult.success) {
-    throw new Error(
-      `Invalid OBZ: generated manifest failed validation — ${manifestResult.error.message}`,
-    );
+    throw new OBFError({
+      code: "invalid-manifest",
+      issues: manifestResult.error.issues,
+      cause: manifestResult.error,
+    });
   }
 
   const manifest = manifestResult.data;
@@ -174,9 +180,12 @@ export async function createOBZ(
   for (const board of boards) {
     const result = OBFBoardSchema.safeParse(board);
     if (!result.success) {
-      throw new Error(
-        `Invalid OBZ: board "${board.id}" failed validation — ${result.error.message}`,
-      );
+      throw new OBFError({
+        code: "invalid-board",
+        boardId: board.id,
+        issues: result.error.issues,
+        cause: result.error,
+      });
     }
     const path = `boards/${result.data.id}.obf`;
     entries.set(path, encoder.encode(JSON.stringify(result.data, null, 2)));
@@ -185,9 +194,7 @@ export async function createOBZ(
   if (resources) {
     for (const [path, bytes] of resources) {
       if (entries.has(path)) {
-        throw new Error(
-          `Invalid OBZ: resource path "${path}" collides with a generated board or manifest entry`,
-        );
+        throw new OBFError({ code: "path-collision", path });
       }
       entries.set(path, bytes);
     }
@@ -225,9 +232,12 @@ function collectMediaPaths(
 
       const existing = paths[media.id];
       if (existing !== undefined && existing !== media.path) {
-        throw new Error(
-          `Invalid OBZ: ${kind} id "${media.id}" maps to conflicting paths "${existing}" and "${media.path}"`,
-        );
+        throw new OBFError({
+          code: "conflicting-paths",
+          kind: kind === "images" ? "image" : "sound",
+          mediaId: media.id,
+          paths: [existing, media.path],
+        });
       }
       paths[media.id] = media.path;
     }
@@ -250,9 +260,12 @@ function assertPathsPresent(
 ): void {
   for (const [id, path] of Object.entries(paths)) {
     if (!entries.has(path)) {
-      throw new Error(
-        `Invalid OBZ: ${kind} "${id}" references "${path}" but no matching resource was supplied`,
-      );
+      throw new OBFError({
+        code: "missing-resource",
+        kind,
+        mediaId: id,
+        path,
+      });
     }
   }
 }
@@ -261,7 +274,7 @@ function extractManifest(entries: Map<string, Uint8Array>): OBFManifest {
   const manifestBytes = entries.get("manifest.json");
 
   if (!manifestBytes) {
-    throw new Error("Invalid OBZ: missing manifest.json");
+    throw new OBFError({ code: "missing-manifest" });
   }
 
   const manifestJson = new TextDecoder().decode(manifestBytes);
@@ -279,18 +292,19 @@ function extractBoards(
     const boardBytes = entries.get(path);
 
     if (!boardBytes) {
-      throw new Error(
-        `Invalid OBZ: board "${id}" declared in manifest but missing at path "${path}"`,
-      );
+      throw new OBFError({ code: "missing-board", boardId: id, path });
     }
 
     const boardJson = new TextDecoder().decode(boardBytes);
     const board = parseOBF(boardJson);
 
     if (board.id !== id) {
-      throw new Error(
-        `Invalid OBZ: board at "${path}" has id "${board.id}" but the manifest declares it as "${id}"`,
-      );
+      throw new OBFError({
+        code: "board-id-mismatch",
+        path,
+        declaredId: id,
+        actualId: board.id,
+      });
     }
 
     boards.set(id, board);
@@ -300,13 +314,7 @@ function extractBoards(
     }
   }
 
-  if (!rootBoard) {
-    // Unreachable for validated manifests: the schema requires `root` to be
-    // listed in `paths.boards`. Kept as a guard for hand-built manifests.
-    throw new Error(
-      `Invalid OBZ: root board "${manifest.root}" not found in paths.boards`,
-    );
-  }
-
-  return { boards, rootBoard };
+  // `OBFManifestSchema` requires `root` to be one of `paths.boards`, so the loop
+  // above always assigns `rootBoard` for the validated manifests we receive.
+  return { boards, rootBoard: rootBoard! };
 }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,0 +1,34 @@
+import { expect } from "vitest";
+import { OBFError } from "./errors";
+import type { OBFErrorInfo } from "./errors";
+
+/**
+ * Assert that `fn` throws an {@link OBFError} and return its `info`, so callers
+ * can make further assertions on the discriminated failure.
+ */
+export function expectOBFError(fn: () => unknown): OBFErrorInfo {
+  try {
+    fn();
+  } catch (error) {
+    expect(error).toBeInstanceOf(OBFError);
+    return (error as OBFError).info;
+  }
+  throw new Error("expected fn to throw an OBFError, but it returned normally");
+}
+
+/**
+ * Assert that `promise` rejects with an {@link OBFError} and return its `info`.
+ */
+export async function expectOBFErrorAsync(
+  promise: Promise<unknown>,
+): Promise<OBFErrorInfo> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).toBeInstanceOf(OBFError);
+    return (error as OBFError).info;
+  }
+  throw new Error(
+    "expected promise to reject with an OBFError, but it resolved",
+  );
+}

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { OBFError } from "./errors";
 import { isZip, unzip, zip } from "./zip";
 
 const encoder = new TextEncoder();
@@ -41,8 +42,6 @@ describe("isZip", () => {
   });
 
   test("returns true for PK followed by arbitrary bytes (false positive accepted)", () => {
-    // Documents that isZip only checks the first 2 bytes;
-    // it does not validate the full ZIP structure.
     const pkFollowedByJunk = new Uint8Array([0x50, 0x4b, 0xff, 0xff, 0x00])
       .buffer;
 
@@ -85,12 +84,15 @@ describe("zip", () => {
 });
 
 describe("unzip", () => {
-  test("rejects with 'Failed to unzip:' error for invalid data", async () => {
+  test("rejects with an unreadable-zip OBFError for invalid data", async () => {
     const invalidData = toArrayBuffer(
       new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04]),
     );
 
-    await expect(unzip(invalidData)).rejects.toThrow(/^Failed to unzip:/);
+    await expect(unzip(invalidData)).rejects.toBeInstanceOf(OBFError);
+    await expect(unzip(invalidData)).rejects.toMatchObject({
+      info: { code: "unreadable-zip" },
+    });
   });
 });
 

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { OBFError } from "./errors";
+import { expectOBFErrorAsync } from "./test-utils";
 import { isZip, unzip, zip } from "./zip";
 
 const encoder = new TextEncoder();
@@ -89,10 +89,9 @@ describe("unzip", () => {
       new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04]),
     );
 
-    await expect(unzip(invalidData)).rejects.toBeInstanceOf(OBFError);
-    await expect(unzip(invalidData)).rejects.toMatchObject({
-      info: { code: "unreadable-zip" },
-    });
+    expect((await expectOBFErrorAsync(unzip(invalidData))).code).toBe(
+      "unreadable-zip",
+    );
   });
 });
 

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -3,6 +3,7 @@
  */
 
 import { unzip as fflateUnzip, zip as fflateZip } from "fflate";
+import { OBFError } from "./errors";
 
 /**
  * First two bytes of every ZIP archive — the ASCII letters `PK`,
@@ -22,7 +23,8 @@ const COMPRESSION_LEVEL = 6;
  * @param archive - The ZIP archive as an `ArrayBuffer`.
  * @returns A map of file paths to their decompressed content.
  *
- * @throws {Error} If the archive is corrupt or cannot be decompressed.
+ * @throws {@link OBFError} with `info.code` `"unreadable-zip"` if the archive is
+ *   corrupt or cannot be decompressed.
  */
 export function unzip(archive: ArrayBuffer): Promise<Map<string, Uint8Array>> {
   return new Promise((resolve, reject) => {
@@ -30,7 +32,7 @@ export function unzip(archive: ArrayBuffer): Promise<Map<string, Uint8Array>> {
 
     fflateUnzip(compressed, (error, entries) => {
       if (error) {
-        reject(new Error(`Failed to unzip: ${error.message ?? String(error)}`));
+        reject(new OBFError({ code: "unreadable-zip", cause: error }));
         return;
       }
 
@@ -51,7 +53,8 @@ export function unzip(archive: ArrayBuffer): Promise<Map<string, Uint8Array>> {
  * @param entries - A map of file paths to their content bytes.
  * @returns The compressed archive as a `Uint8Array`.
  *
- * @throws {Error} If fflate fails to compress an entry.
+ * @throws {@link OBFError} with `info.code` `"zip-failed"` if fflate fails to
+ *   compress an entry.
  */
 export function zip(
   entries: Map<string, Uint8Array | ArrayBuffer>,
@@ -66,7 +69,7 @@ export function zip(
 
     fflateZip(pathToBytes, { level: COMPRESSION_LEVEL }, (error, result) => {
       if (error) {
-        reject(new Error(`Failed to zip: ${error.message ?? String(error)}`));
+        reject(new OBFError({ code: "zip-failed", cause: error }));
         return;
       }
 

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -32,7 +32,7 @@ export function unzip(archive: ArrayBuffer): Promise<Map<string, Uint8Array>> {
 
     fflateUnzip(compressed, (error, entries) => {
       if (error) {
-        reject(new OBFError({ code: "unreadable-zip", cause: error }));
+        reject(new OBFError({ code: "unreadable-zip" }, { cause: error }));
         return;
       }
 
@@ -69,7 +69,7 @@ export function zip(
 
     fflateZip(pathToBytes, { level: COMPRESSION_LEVEL }, (error, result) => {
       if (error) {
-        reject(new OBFError({ code: "zip-failed", cause: error }));
+        reject(new OBFError({ code: "zip-failed" }, { cause: error }));
         return;
       }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { coverageConfigDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
@@ -6,6 +6,7 @@ export default defineConfig({
     unstubGlobals: true,
     coverage: {
       include: ["src/**/*.ts"],
+      exclude: [...coverageConfigDefaults.exclude, "src/test-utils.ts"],
       thresholds: {
         statements: 95,
         branches: 80,


### PR DESCRIPTION
## Summary

Replaces plain `Error` throws with a typed **`OBFError`** that carries a discriminated `error.info`. Consumers now branch on `error.info.code` (e.g. `"missing-resource"`, `"invalid-board"`, `"not-zip"`) and read structured fields off each variant — no more message-string parsing.

- **New exports:** `OBFError` (class) plus the `OBFErrorInfo`, `OBFErrorCode`, and `OBFIssue` types.
- Validation failures (`invalid-board`, `invalid-manifest`) carry the Zod `issues` list plus the underlying `ZodError` as `error.cause`; decode failures (`not-json`, `unreadable-zip`, `zip-failed`) carry the underlying error as `cause`.
- `OBFIssue` aliases `z.core.$ZodIssue` — the issue type Zod v4 designates for downstream libraries (the bare `z.ZodIssue` is deprecated in its favor) — so consumers get a stable OBF-named type without reaching into Zod's `core` export.
- **Breaking:** thrown errors are now `OBFError` (`error.name` is `"OBFError"`) and message strings changed. Branch on `error.info.code` rather than matching `error.message`. The internal `buildJsonParseErrorMessage` helper was removed.

## Changeset

Included (`.changeset/typed-obf-errors.md`, `minor`). Note: marked `minor` since the package is pre-1.0; the body documents the breaking surface.

## Test plan

- [x] `npm test` — 135 passing (new `src/errors.test.ts` covers the typed error surface)
- [x] `tsc`, `eslint`, and `prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)