### PR TITLE
fix: enforce absolute-positioning completeness and relax manifest paths

### DIFF
--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -337,6 +337,26 @@ describe("OBFButtonSchema", () => {
     expect(OBFButtonSchema.safeParse(outOfBoundsWidth).success).toBe(false);
   });
 
+  test("accepts a button with no positioning attributes", () => {
+    const gridOnlyButton = { id: "1", label: "happy" };
+
+    expect(OBFButtonSchema.safeParse(gridOnlyButton).success).toBe(true);
+  });
+
+  test("rejects a partial positioning set", () => {
+    const missingHeight = {
+      id: "1",
+      top: 0.2,
+      left: 0.3,
+      width: 0.1,
+    };
+
+    expect(OBFButtonSchema.safeParse(missingHeight).success).toBe(false);
+    expect(OBFButtonSchema.safeParse({ id: "1", top: 0.2 }).success).toBe(
+      false,
+    );
+  });
+
   test("accepts button with actions array and load_board, coerces nested ID", () => {
     const buttonWithActionsAndLoadBoard = {
       id: "nav-btn",
@@ -551,14 +571,14 @@ describe("OBFManifestSchema", () => {
     expect(OBFManifestSchema.safeParse(missingBoards).success).toBe(false);
   });
 
-  test("requires images in paths", () => {
-    const missingImages = {
+  test("accepts manifest without images (optional)", () => {
+    const noImages = {
       format: "open-board-0.1",
       root: "boards/main.obf",
       paths: { boards: { main: "boards/main.obf" } },
     };
 
-    expect(OBFManifestSchema.safeParse(missingImages).success).toBe(false);
+    expect(OBFManifestSchema.safeParse(noImages).success).toBe(true);
   });
 
   test("rejects root not listed in paths.boards", () => {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -261,42 +261,55 @@ export type OBFLoadBoard = z.infer<typeof OBFLoadBoardSchema>;
 /**
  * Interactive element on a board, optionally linked to images, sounds, and actions.
  */
-export const OBFButtonSchema = z.looseObject({
-  /** Unique identifier for the button. */
-  id: OBFIDSchema,
-  /** Label text displayed on the button. */
-  label: z.string().optional(),
-  /** Alternative text for vocalization when the button is activated. */
-  vocalization: z.string().optional(),
-  /** Identifier of the image associated with the button. */
-  image_id: OBFOptionalIDSchema,
-  /** Identifier of the sound associated with the button. */
-  sound_id: OBFOptionalIDSchema,
-  /**
-   * Action triggered by the button. When `actions` is also set, this is
-   * the single-action fallback for apps that support one action per button.
-   */
-  action: OBFButtonActionSchema.optional(),
-  /**
-   * Multiple actions executed in order. Apps that support it should
-   * prefer this over the single `action` fallback.
-   */
-  actions: z.array(OBFButtonActionSchema).optional(),
-  /** Information to load another board when this button is activated. */
-  load_board: OBFLoadBoardSchema.optional(),
-  /** Background color of the button in `rgb` or `rgba` format. */
-  background_color: z.string().optional(),
-  /** Border color of the button in `rgb` or `rgba` format. */
-  border_color: z.string().optional(),
-  /** Vertical position for absolute positioning (0.0 to 1.0). */
-  top: z.number().min(0).max(1).optional(),
-  /** Horizontal position for absolute positioning (0.0 to 1.0). */
-  left: z.number().min(0).max(1).optional(),
-  /** Width of the button for absolute positioning (0.0 to 1.0). */
-  width: z.number().min(0).max(1).optional(),
-  /** Height of the button for absolute positioning (0.0 to 1.0). */
-  height: z.number().min(0).max(1).optional(),
-});
+export const OBFButtonSchema = z
+  .looseObject({
+    /** Unique identifier for the button. */
+    id: OBFIDSchema,
+    /** Label text displayed on the button. */
+    label: z.string().optional(),
+    /** Alternative text for vocalization when the button is activated. */
+    vocalization: z.string().optional(),
+    /** Identifier of the image associated with the button. */
+    image_id: OBFOptionalIDSchema,
+    /** Identifier of the sound associated with the button. */
+    sound_id: OBFOptionalIDSchema,
+    /**
+     * Action triggered by the button. When `actions` is also set, this is
+     * the single-action fallback for apps that support one action per button.
+     */
+    action: OBFButtonActionSchema.optional(),
+    /**
+     * Multiple actions executed in order. Apps that support it should
+     * prefer this over the single `action` fallback.
+     */
+    actions: z.array(OBFButtonActionSchema).optional(),
+    /** Information to load another board when this button is activated. */
+    load_board: OBFLoadBoardSchema.optional(),
+    /** Background color of the button in `rgb` or `rgba` format. */
+    background_color: z.string().optional(),
+    /** Border color of the button in `rgb` or `rgba` format. */
+    border_color: z.string().optional(),
+    /** Vertical position for absolute positioning (0.0 to 1.0). */
+    top: z.number().min(0).max(1).optional(),
+    /** Horizontal position for absolute positioning (0.0 to 1.0). */
+    left: z.number().min(0).max(1).optional(),
+    /** Width of the button for absolute positioning (0.0 to 1.0). */
+    width: z.number().min(0).max(1).optional(),
+    /** Height of the button for absolute positioning (0.0 to 1.0). */
+    height: z.number().min(0).max(1).optional(),
+  })
+  .refine(
+    (b) => {
+      const set = [b.top, b.left, b.width, b.height].filter(
+        (v) => v !== undefined,
+      );
+      return set.length === 0 || set.length === 4;
+    },
+    {
+      message:
+        "Absolute positioning requires all of top, left, width, and height (or none)",
+    },
+  );
 
 /**
  * Interactive element on a board, optionally linked to images, sounds, and
@@ -382,7 +395,7 @@ export const OBFManifestSchema = z
       /** Mapping of board IDs to their file paths. */
       boards: z.record(z.string(), z.string()),
       /** Mapping of image IDs to their file paths. */
-      images: z.record(z.string(), z.string()),
+      images: z.record(z.string(), z.string()).optional(),
       /** Mapping of sound IDs to their file paths. */
       sounds: z.record(z.string(), z.string()).optional(),
     }),


### PR DESCRIPTION
Two validation changes to align `src/schema.ts` with the OBF spec (`docs/external/open-board-format.md`), found via a section-by-section drift audit.

## Changes

**1. Absolute-positioning all-four-or-none (`OBFButtonSchema`)**
The spec states *"All four attributes are required for all buttons"* when absolute positioning is used ([open-board-format.md:319](../blob/main/docs/external/open-board-format.md)). The schema previously declared `top`/`left`/`width`/`height` each independently `.optional()`, so it accepted spec-invalid partial sets like `{ top: 0.2 }`. Added a `.refine()` enforcing all-four-or-none; grid-only buttons (no positioning) still pass.

**2. Manifest paths consistency (`OBFManifestSchema`)**
`paths.images` was required while `paths.sounds` was optional — an asymmetry with no spec basis. Made `paths.images` optional too, so the three sibling maps are consistent and the reader tolerates third-party `.obz` manifests that omit empty maps. `paths.boards` stays required (the root-in-boards refine and `parseOBZ` depend on it).

## Notes
- #1 is **stricter** validation; #2 is **looser**. No changeset added — pre-release, no consumers yet.

## Verification
- `tsc` clean
- 138/138 tests pass (2 new button cases + flipped manifest-images test)
- eslint + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)