### PR TITLE
chore: add changeset for schema validation alignment (minor)

### DIFF
--- a/.changeset/strict-absolute-positioning.md
+++ b/.changeset/strict-absolute-positioning.md
@@ -1,0 +1,8 @@
+---
+"@shayc/open-board-format": minor
+---
+
+Align board validation with the OBF spec:
+
+- **Buttons:** absolute positioning now requires all of `top`, `left`, `width`, and `height` together (or none of them), matching the spec's "all four attributes are required for all buttons" rule. A partial positioning set (e.g. only `top`) is now rejected; grid-only buttons are unaffected.
+- **OBZ manifest:** `paths.images` is now optional (consistent with `paths.sounds`), so manifests that omit empty image/sound maps validate. `paths.boards` remains required.


### PR DESCRIPTION
Adds a `minor` changeset to release the validation changes from #52.

- **Bump:** `@shayc/open-board-format` 0.5.0 → 0.6.0
- **Why minor:** the absolute-positioning refine tightens validation observably; pre-1.0 a behavior change goes minor.

Merging this lands the changeset on `main`; the Release workflow then opens a **Version Packages** PR, and merging that publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)