### PR TITLE
test: remove redundant tests and consolidate parallel cases

### DIFF
--- a/src/load-board.test.ts
+++ b/src/load-board.test.ts
@@ -49,18 +49,6 @@ describe("loadBoard", () => {
     expect(loaded).toEqual({ format: "obf", board: validBoard });
   });
 
-  test("loads an OBZ package from an ArrayBuffer", async () => {
-    const obzBlob = await createOBZ([validBoard], "test-board");
-
-    const loaded = await loadBoard(await obzBlob.arrayBuffer());
-
-    expect(loaded.format).toBe("obz");
-    if (loaded.format !== "obz") {
-      throw new Error("expected obz");
-    }
-    expect(loaded.archive.boards.get("test-board")).toEqual(validBoard);
-  });
-
   test("detects format by content, not by file extension", async () => {
     const obzBlob = await createOBZ([validBoard], "test-board");
     const file = new File([obzBlob], "actually-a-package.obf");

--- a/src/obf.test.ts
+++ b/src/obf.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { OBFError } from "./errors";
 import { loadOBF, parseOBF, stringifyOBF, validateOBF } from "./obf";
-import { expectOBFError, makeBoard } from "./test-utils";
+import { makeBoard } from "./test-utils";
 
 const validBoard = makeBoard({
   id: "test-board",
@@ -47,18 +47,6 @@ describe("validateOBF", () => {
   test("accepts valid board structure", () => {
     expect(() => validateOBF(validBoard)).not.toThrow();
   });
-
-  test("throws for missing required grid field", () => {
-    const boardWithoutGrid: unknown = {
-      format: "open-board-0.1",
-      id: "test-board",
-      buttons: [],
-    };
-
-    expect(expectOBFError(() => validateOBF(boardWithoutGrid)).code).toBe(
-      "invalid-board",
-    );
-  });
 });
 
 describe("loadOBF", () => {
@@ -78,18 +66,5 @@ describe("OBF round-trip", () => {
     const parsed = parseOBF(json);
 
     expect(parsed).toEqual(validBoard);
-  });
-
-  test("round-trip preserves ext_ fields at button level", () => {
-    const boardWithButtonExt = makeBoard({
-      id: "ext-button-board",
-      buttons: [{ id: "b1", label: "Hi", ext_myapp_anim: "fade" }],
-      grid: { rows: 1, columns: 1, order: [["b1"]] },
-    });
-
-    const parsed = parseOBF(stringifyOBF(boardWithButtonExt));
-    expect((parsed.buttons[0] as Record<string, unknown>).ext_myapp_anim).toBe(
-      "fade",
-    );
   });
 });

--- a/src/obz.test.ts
+++ b/src/obz.test.ts
@@ -24,18 +24,6 @@ describe("parseManifest", () => {
     expect(manifest.paths.boards.test).toBe("boards/test.obf");
   });
 
-  test("throws for invalid manifest format", () => {
-    const invalidManifest = JSON.stringify({
-      format: "wrong-format",
-      root: "boards/test.obf",
-      paths: { boards: { test: "boards/test.obf" }, images: {} },
-    });
-
-    expect(expectOBFError(() => parseManifest(invalidManifest)).code).toBe(
-      "invalid-manifest",
-    );
-  });
-
   test("throws when root is not listed in paths.boards", () => {
     const rootNotListed = JSON.stringify({
       format: "open-board-0.1",
@@ -348,25 +336,6 @@ describe("createOBZ", () => {
 });
 
 describe("Integration: createOBZ and extractOBZ", () => {
-  test("round-trip preserves boards", async () => {
-    const original = makeBoard({
-      id: "board-1",
-      buttons: [{ id: "btn-1", label: "Test" }],
-      grid: { rows: 1, columns: 1, order: [["btn-1"]] },
-    });
-
-    const obzBlob = await createOBZ([original], "board-1");
-    const obzBuffer = await obzBlob.arrayBuffer();
-    const extracted = await extractOBZ(obzBuffer);
-
-    expect(extracted.manifest.root).toBe("boards/board-1.obf");
-    expect(extracted.rootBoard).toBe(extracted.boards.get("board-1"));
-    expect(extracted.boards.get("board-1")).toMatchObject({
-      id: "board-1",
-      buttons: [{ id: "btn-1", label: "Test" }],
-    });
-  });
-
   test("round-trip handles multiple boards", async () => {
     const board1 = makeBoard({
       id: "board-1",

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -252,16 +252,6 @@ describe("OBFImageSchema", () => {
 
     expect(OBFImageSchema.safeParse(validImage).success).toBe(true);
   });
-
-  test("accepts image without dimensions", () => {
-    const validImage = {
-      id: "img3",
-      path: "images/icon.png",
-      content_type: "image/png",
-    };
-
-    expect(OBFImageSchema.safeParse(validImage).success).toBe(true);
-  });
 });
 
 describe("OBFButtonSchema", () => {
@@ -323,18 +313,6 @@ describe("OBFButtonSchema", () => {
     };
 
     expect(OBFButtonSchema.safeParse(outOfBoundsLeft).success).toBe(false);
-  });
-
-  test("rejects out-of-bounds width", () => {
-    const outOfBoundsWidth = {
-      id: "1",
-      top: 0,
-      left: 0,
-      width: 1.5,
-      height: 0.1,
-    };
-
-    expect(OBFButtonSchema.safeParse(outOfBoundsWidth).success).toBe(false);
   });
 
   test("accepts a button with no positioning attributes", () => {
@@ -431,16 +409,11 @@ describe("OBFGridSchema", () => {
     }
   });
 
-  test("rejects zero rows", () => {
-    const zeroRows = { rows: 0, columns: 1, order: [] };
-
-    expect(OBFGridSchema.safeParse(zeroRows).success).toBe(false);
-  });
-
-  test("rejects negative columns", () => {
-    const negativeColumns = { rows: 1, columns: -1, order: [[]] };
-
-    expect(OBFGridSchema.safeParse(negativeColumns).success).toBe(false);
+  test.each([
+    ["zero rows", { rows: 0, columns: 1, order: [] }],
+    ["negative columns", { rows: 1, columns: -1, order: [[]] }],
+  ])("rejects %s (violates the min(1) integer bound)", (_label, grid) => {
+    expect(OBFGridSchema.safeParse(grid).success).toBe(false);
   });
 
   test("rejects float rows", () => {
@@ -571,16 +544,6 @@ describe("OBFManifestSchema", () => {
     expect(OBFManifestSchema.safeParse(missingBoards).success).toBe(false);
   });
 
-  test("accepts manifest without images (optional)", () => {
-    const noImages = {
-      format: "open-board-0.1",
-      root: "boards/main.obf",
-      paths: { boards: { main: "boards/main.obf" } },
-    };
-
-    expect(OBFManifestSchema.safeParse(noImages).success).toBe(true);
-  });
-
   test("rejects root not listed in paths.boards", () => {
     const rootNotListed = {
       format: "open-board-0.1",
@@ -589,19 +552,6 @@ describe("OBFManifestSchema", () => {
     };
 
     expect(OBFManifestSchema.safeParse(rootNotListed).success).toBe(false);
-  });
-
-  test("accepts manifest without sounds (optional)", () => {
-    const noSounds = {
-      format: "open-board-0.1",
-      root: "boards/main.obf",
-      paths: {
-        boards: { main: "boards/main.obf" },
-        images: { icon: "images/icon.png" },
-      },
-    };
-
-    expect(OBFManifestSchema.safeParse(noSounds).success).toBe(true);
   });
 });
 

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -29,16 +29,11 @@ describe("isZip", () => {
     expect(isZip(notPk)).toBe(false);
   });
 
-  test("returns false for 1-byte buffer (too short for PK)", () => {
-    const oneByte = new Uint8Array([0x50]).buffer;
-
-    expect(isZip(oneByte)).toBe(false);
-  });
-
-  test("returns false for empty buffer", () => {
-    const empty = new Uint8Array([]).buffer;
-
-    expect(isZip(empty)).toBe(false);
+  test.each([
+    ["empty", [] as number[]],
+    ["1-byte", [0x50]],
+  ])("returns false for %s buffer (shorter than the 2-byte PK signature)", (_label, bytes) => {
+    expect(isZip(new Uint8Array(bytes).buffer)).toBe(false);
   });
 
   test("returns true for PK followed by arbitrary bytes (false positive accepted)", () => {


### PR DESCRIPTION
## Summary
Prunes the test suite of redundant/tautological cases and consolidates over-parallel ones, with **no change to coverage**.

### Removed (9 — coverage provided elsewhere)
- **schema.test.ts** — "accepts image without dimensions", "rejects out-of-bounds width" (parallel to top/left), "accepts manifest without images", "accepts manifest without sounds" (all tautological Zod `.optional()`)
- **obf.test.ts** — "throws for missing required grid field" (subsumed by errors.test.ts + schema "requires grid field"), "round-trip preserves ext_ fields at button level" (covered by the schema ext_ test)
- **obz.test.ts** — "throws for invalid manifest format" (subsumed by errors.test.ts, stronger assertion), "round-trip preserves boards" (subsumed by "extracts valid OBZ archive")
- **load-board.test.ts** — "loads an OBZ package from an ArrayBuffer" (ArrayBuffer branch + OBZ dispatch already covered)

### Consolidated (→ `test.each`)
- grid `min(1)`: "rejects zero rows" + "rejects negative columns"
- zip short-buffer: "1-byte buffer" + "empty buffer"

Also drops the now-unused `expectOBFError` import in obf.test.ts.

## Verification
- `tsc --noEmit` clean, `eslint` clean
- **129 tests pass** (was 138)
- Coverage unchanged: 98.25% stmts / 92.4% branch / **100% funcs** / 98.23% lines — all enforced thresholds clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)