### PR TITLE
chore!: cut 1.0 (zod → peer dependency)

### DIFF
--- a/.changeset/zod-peer-dependency.md
+++ b/.changeset/zod-peer-dependency.md
@@ -1,6 +1,8 @@
 ---
-"@shayc/open-board-format": minor
+"@shayc/open-board-format": major
 ---
+
+First stable release. The public API — every exported function, type, and Zod schema — is now covered by semver; breaking changes will ship as major versions.
 
 **Breaking:** `zod` is now a peer dependency instead of a bundled dependency. Install it alongside this package:
 

--- a/.changeset/zod-peer-dependency.md
+++ b/.changeset/zod-peer-dependency.md
@@ -1,0 +1,11 @@
+---
+"@shayc/open-board-format": minor
+---
+
+**Breaking:** `zod` is now a peer dependency instead of a bundled dependency. Install it alongside this package:
+
+```bash
+npm install zod@^4
+```
+
+npm 7+ installs the peer automatically; pnpm and Yarn users must add `zod` explicitly. This makes your app and this package share a single `zod` instance, so the exported schemas (`OBFBoardSchema`, `OBFButtonSchema`, …) and the `OBFIssue` type compose against your own `zod` without duplicate-copy type mismatches.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ A TypeScript toolkit for [Open Board Format](https://www.openboardformat.org/) �
 - **Browser and Node.js 22+** — pure ESM, works against `File` and `ArrayBuffer`.
 - **One entry point for either format** — `loadBoard` sniffs the bytes and tells you whether it found an `.obf` board or an `.obz` package.
 - **Spec-faithful round trips** — unknown fields are preserved rather than stripped, so vendor extensions allowed by the OBF spec survive `parseOBF` → `stringifyOBF`.
-- **Small footprint** — two runtime dependencies (Zod and [fflate](https://github.com/101arrowz/fflate)), tree-shakeable, no side effects.
+- **Small footprint** — one bundled dependency ([fflate](https://github.com/101arrowz/fflate)) plus Zod as a peer, tree-shakeable, no side effects.
 
 ## Install
 
 ```bash
-npm install @shayc/open-board-format
+npm install @shayc/open-board-format zod
 ```
+
+`zod` 4 is a peer dependency — npm 7+ installs it automatically, but pnpm and Yarn users should add it explicitly (as shown above).
 
 ESM only — CommonJS (`require`) is not supported.
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ What this library deliberately does not do:
 
 ## Versioning
 
-Semver. Pre-1.0: minor releases may contain breaking changes — see [CHANGELOG.md](CHANGELOG.md).
+Semver. The public API — every exported function, type, and Zod schema — is stable; breaking changes ship as major releases. See [CHANGELOG.md](CHANGELOG.md).
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "@shayc/open-board-format",
-  "version": "0.2.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shayc/open-board-format",
-      "version": "0.2.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
-        "fflate": "^0.8.3",
-        "zod": "^4.4.3"
+        "fflate": "^0.8.3"
       },
       "devDependencies": {
         "@changesets/cli": "^2.31.0",
@@ -25,10 +24,14 @@
         "tsdown": "^0.22.2",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.61.0",
-        "vitest": "^4.1.8"
+        "vitest": "^4.1.8",
+        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^4.4.3"
       }
     },
     "node_modules/@babel/generator": {
@@ -4790,6 +4793,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
     "node": ">=22"
   },
   "dependencies": {
-    "fflate": "^0.8.3",
+    "fflate": "^0.8.3"
+  },
+  "peerDependencies": {
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -69,7 +71,8 @@
     "tsdown": "^0.22.2",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.61.0",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.8",
+    "zod": "^4.4.3"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
Makes `zod` a **peer dependency** instead of a bundled one. zod is part of this package's public API — 18 exported schemas (`OBFBoardSchema`, …) advertised for composition, plus `OBFIssue` (= `z.core.$ZodIssue`) in the error model. For a schema-exporting library, the consumer and this package must share **one** zod instance, or composing the exported schemas with the consumer's own `z.object(...)` hits duplicate-copy type-identity mismatches.

## Changes
- `package.json`: `zod` moved `dependencies → peerDependencies` (`^4.4.3`), added to `devDependencies` (for build/test). `fflate` stays a regular dependency (internal only).
- `package-lock.json` regenerated.
- README: install command now includes `zod`, with a note that npm 7+ auto-installs the peer while pnpm/Yarn users add it explicitly; "footprint" bullet updated.
- Changeset added — **minor** bump (→ `0.7.0`), flagged breaking per the pre-1.0 policy.

## Migration (for consumers)
```bash
npm install zod@^4   # npm 7+ installs the peer automatically; pnpm/Yarn must add it
```

## Verification
- `lint` / `format:check` / `typecheck` / `tests` / `build` all pass
- `publint`: All good!
- `changeset status`: bumps `@shayc/open-board-format` at minor

## Note on versioning
This is queued as **0.7.0** (breaking, pre-1.0). If you'd rather this land *as* the 1.0 cut, change the changeset bump from `minor` to `major` before merging the Version Packages PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)