### PR TITLE
fix: percent-encode board ids into OBZ archive paths

### DIFF
--- a/.changeset/wild-tigers-cheer.md
+++ b/.changeset/wild-tigers-cheer.md
@@ -1,0 +1,5 @@
+---
+"@shayc/open-board-format": patch
+---
+
+Percent-encode board ids into OBZ archive paths, preventing a crafted board id (e.g. containing `../` or `/`) from writing outside the `boards/` directory.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ const resources = new Map([["images/hello.png", pngBytes]]);
 const blob = await createOBZ([board], "board-1", resources);
 ```
 
-The `manifest.json` is generated for you — boards are written to `boards/<id>.obf`, and `rootBoardId` (the second argument) selects the home board.
+The `manifest.json` is generated for you — boards are written to `boards/<id>.obf` (the id is percent-encoded, so it's always a safe filename), and `rootBoardId` (the second argument) selects the home board.
 
 ### Validate with Zod directly
 

--- a/src/obz.test.ts
+++ b/src/obz.test.ts
@@ -212,6 +212,18 @@ describe("createOBZ", () => {
     ).toMatchObject({ code: "duplicate-board", boardId: "dup" });
   });
 
+  test.each(["../evil", "a/b", "a\\b"])(
+    "percent-encodes path-like board ids into a safe filename (%s)",
+    async (id) => {
+      const blob = await createOBZ([makeBoard({ id })], id);
+      const extracted = await extractOBZ(await blob.arrayBuffer());
+
+      const path = extracted.manifest.paths.boards[id];
+      expect(path).toMatch(/^boards\/[^/\\]+\.obf$/);
+      expect(extracted.rootBoard.id).toBe(id);
+    },
+  );
+
   test("throws when a supplied board fails schema validation", async () => {
     const invalidBoard = {
       format: "open-board-0.1",

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -145,7 +145,7 @@ export async function createOBZ(
   const entries = new Map<string, Uint8Array | ArrayBuffer>();
 
   const boardPaths = Object.fromEntries(
-    boards.map((board) => [board.id, `boards/${board.id}.obf`]),
+    boards.map((board) => [board.id, boardPath(board.id)]),
   );
 
   const imagePaths = collectMediaPaths(boards, "images");
@@ -153,7 +153,7 @@ export async function createOBZ(
 
   const manifestResult = OBFManifestSchema.safeParse({
     format: "open-board-0.1",
-    root: `boards/${rootBoardId}.obf`,
+    root: boardPath(rootBoardId),
     paths: {
       boards: boardPaths,
       images: imagePaths,
@@ -191,8 +191,10 @@ export async function createOBZ(
         { cause: result.error },
       );
     }
-    const path = `boards/${result.data.id}.obf`;
-    entries.set(path, encoder.encode(JSON.stringify(result.data, null, 2)));
+    entries.set(
+      boardPaths[result.data.id],
+      encoder.encode(JSON.stringify(result.data, null, 2)),
+    );
   }
 
   if (resources) {
@@ -214,6 +216,19 @@ export async function createOBZ(
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Derive a board's archive path from its id.
+ *
+ * Board ids are spec-legal as any non-empty string, but archive paths give
+ * `/` and `\` structural meaning. Percent-encoding the id keeps the mapping
+ * deterministic and collision-free without rejecting any id the schema
+ * already allows — a `/` or `..` in the id just becomes part of a filename,
+ * never a path segment.
+ */
+function boardPath(id: string): string {
+  return `boards/${encodeURIComponent(id)}.obf`;
+}
 
 /**
  * Walk every board's media collection and produce the `{ id -> path }` map


### PR DESCRIPTION
## Summary
- Board ids are schema-legal as any non-empty string, so an id containing `/`, `\`, or `..` could previously produce a manifest/archive path that escapes the intended `boards/` directory.
- `createOBZ` now derives archive paths via a `boardPath()` helper that percent-encodes the id, keeping the mapping deterministic and collision-free without rejecting any id the schema already allows.
- Also clarifies in the README that generated board paths are always a safe filename.

## Test plan
- [x] `npm test` (136 tests passing)
- [x] Added parameterized test covering path-like board ids (`../evil`, `a/b`, `a\b`) asserting the resulting manifest path stays within `boards/` and round-trips correctly through `extractOBZ`

🤖 Generated with [Claude Code](https://claude.com/claude-code)