### PR TITLE
fix: drop directory entries when unzipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ What this library deliberately does not do:
 - **No network I/O** — media referenced by `url` or `data_url` is not fetched; resolving external media is up to you.
 - **No rendering** — it parses and validates data; drawing boards and playing sounds belong to your app.
 - **No extraction limits or path sanitization** — see [Security](#security) before writing archive contents to disk.
+- **No referential integrity checks** — a `grid.order` id with no matching button, or an `image_id`/`sound_id` with no matching image/sound, is not flagged. Resolving references is up to your rendering layer.
 
 ## Versioning
 

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -91,6 +91,18 @@ describe("unzip", () => {
       "unreadable-zip",
     );
   });
+
+  test("drops directory entries, keeping only file paths", async () => {
+    const files = new Map<string, Uint8Array>([
+      ["folder/", new Uint8Array(0)],
+      ["folder/file.txt", encoder.encode("content")],
+    ]);
+
+    const zipped = await zip(files);
+    const unzipped = await unzip(toArrayBuffer(zipped));
+
+    expect([...unzipped.keys()]).toEqual(["folder/file.txt"]);
+  });
 });
 
 describe("Integration: zip and unzip", () => {

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -20,6 +20,10 @@ const COMPRESSION_LEVEL = 6;
 /**
  * Decompress a ZIP archive into a map of file paths to raw bytes.
  *
+ * Directory entries (paths ending in `/`, which some tools write explicitly
+ * even though ZIP doesn't require them) are dropped — they carry no content
+ * and this map is documented as file paths to bytes.
+ *
  * @param archive - The ZIP archive as an `ArrayBuffer`.
  * @returns A map of file paths to their decompressed content.
  *
@@ -36,7 +40,9 @@ export function unzip(archive: ArrayBuffer): Promise<Map<string, Uint8Array>> {
         return;
       }
 
-      const pathToBytes = new Map<string, Uint8Array>(Object.entries(entries));
+      const pathToBytes = new Map(
+        Object.entries(entries).filter(([path]) => !path.endsWith("/")),
+      );
 
       resolve(pathToBytes);
     });


### PR DESCRIPTION
## Summary
- `unzip` now filters out directory-marker entries (paths ending in `/`) so `resources` maps only ever contain real file content, matching its documented contract.
- Documents in the README that OBF/OBZ validation is structural only — dangling `grid.order`/`image_id`/`sound_id` references are intentionally not checked (real-world boards are sometimes sloppy this way; resolving references is the rendering layer's job).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test:coverage` (137 tests, 100% coverage)
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)