### PR TITLE
chore: add missing changeset for #68, gate CI on changesets

### DIFF
--- a/.changeset/tame-otters-flow.md
+++ b/.changeset/tame-otters-flow.md
@@ -1,0 +1,5 @@
+---
+"@shayc/open-board-format": patch
+---
+
+Drop directory-marker entries (paths ending in `/`) when unzipping, so `extractOBZ`'s `resources` map only ever contains real file content.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,22 @@ jobs:
       - run: npm run typecheck
       - run: npm run test:coverage
       - run: npm run build
+
+  changeset:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Require a changeset when src/ changes
+        run: |
+          git fetch origin "${{ github.base_ref }}" --quiet
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- src/ | grep -q .; then
+            if ! git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- .changeset \
+                | grep -v -E '(config\.json|README\.md)' | grep -q .; then
+              echo "::error::This PR changes src/ but adds no changeset. Run 'npm run changeset' to record a patch/minor/major bump."
+              exit 1
+            fi
+          fi


### PR DESCRIPTION
## Summary
- Adds the changeset that #68 (drop directory entries when unzipping) should have shipped with — it changed the `resources` map's observable contents for archives with directory entries, so it needs a patch release.
- Adds a `changeset` CI job that fails a PR touching `src/` if it doesn't add a `.changeset/*.md` file, catching this class of miss going forward. Docs-only and dependency-bump PRs (which correctly skip changesets) are unaffected since the check only triggers when `src/` changes.

## Test plan
- [x] `npm run test:coverage` (137 tests, 100% coverage, unaffected)
- [ ] Confirm the new `changeset` CI job passes on this PR (touches only `.changeset/` and `.github/`, no `src/` change, so it should skip its own gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)