### PR TITLE
Misc fixes: OBZ manifest paths, Blob/ArrayBufferView input, stricter tsconfig

### DIFF
--- a/.changeset/tame-carrots-fix.md
+++ b/.changeset/tame-carrots-fix.md
@@ -1,0 +1,5 @@
+---
+"@shayc/open-board-format": minor
+---
+
+`loadBoard` and `extractOBZ` now accept a `Blob` or any typed-array view (e.g. a Node `Buffer`/`Uint8Array`) in addition to `File` and `ArrayBuffer`, instead of throwing a raw `TypeError` on those inputs. This removes the need to manually slice a `Buffer` into an `ArrayBuffer` before calling `loadBoard` in Node.

--- a/.changeset/tidy-eels-clap.md
+++ b/.changeset/tidy-eels-clap.md
@@ -1,0 +1,5 @@
+---
+"@shayc/open-board-format": patch
+---
+
+`createOBZ` now always emits both `paths.images` and `paths.sounds` in the generated manifest, even when empty, matching the spec's example manifest instead of omitting `sounds` when there are none.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ my-board.obz
 ```
 
 - **Typed end to end** — every type is inferred from a [Zod](https://zod.dev/) schema, and every schema is exported for `safeParse` or composing into your own contracts.
-- **Browser and Node.js 22+** — pure ESM, works against `File` and `ArrayBuffer`.
+- **Browser and Node.js 22+** — pure ESM, works against `File`, `Blob`, `ArrayBuffer`, or any typed-array view (e.g. Node's `Buffer`).
 - **One entry point for either format** — `loadBoard` sniffs the bytes and tells you whether it found an `.obf` board or an `.obz` package.
 - **Spec-faithful round trips** — unknown fields are preserved rather than stripped, so vendor extensions allowed by the OBF spec survive `parseOBF` → `stringifyOBF`.
 - **Small footprint** — one runtime dependency ([fflate](https://github.com/101arrowz/fflate)) plus Zod as a peer, tree-shakeable, no side effects.
@@ -50,18 +50,15 @@ if (loaded.format === "obf") {
 }
 ```
 
-`loadBoard` accepts a `File` or `ArrayBuffer` and throws on invalid input (see [Errors](#errors)). Already holding a JSON string? `parseOBF(json)` returns a validated `OBFBoard` directly.
+`loadBoard` accepts a `File`, `Blob`, `ArrayBuffer`, or any typed-array view (e.g. a Node `Buffer`), and throws on invalid input (see [Errors](#errors)). Already holding a JSON string? `parseOBF(json)` returns a validated `OBFBoard` directly.
 
-In Node.js, read the file to a buffer first — there's no `File` API outside the browser:
+In Node.js, read the file first — there's no `File` API outside the browser, but `readFile`'s `Buffer` works directly:
 
 ```ts
 import { readFile } from "node:fs/promises";
 import { loadBoard } from "@shayc/open-board-format";
 
-const { buffer, byteOffset, byteLength } = await readFile("my-board.obz");
-const loaded = await loadBoard(
-  buffer.slice(byteOffset, byteOffset + byteLength),
-);
+const loaded = await loadBoard(await readFile("my-board.obz"));
 ```
 
 ## Usage
@@ -69,7 +66,7 @@ const loaded = await loadBoard(
 ### Which function do I need?
 
 - **You have a single board (OBF).** Use `parseOBF` for a JSON string, `validateOBF` for an already-parsed object, `loadOBF` for a browser `File`. `stringifyOBF` serializes back out.
-- **You have a package of boards plus media (OBZ).** Use `loadOBZ` for a `File`, `extractOBZ` for an `ArrayBuffer`, `createOBZ` to build a new one.
+- **You have a package of boards plus media (OBZ).** Use `extractOBZ` for a `File`, `Blob`, `ArrayBuffer`, or typed-array view (`loadOBZ` is the same thing, `File`-only); `createOBZ` to build a new one.
 - **You don't know which you have.** Use `loadBoard` — it sniffs the bytes and returns a `{ format, ... }` union so you don't have to inspect the file extension yourself.
 
 ### Read an OBZ package
@@ -80,7 +77,7 @@ import { loadOBZ, extractOBZ } from "@shayc/open-board-format";
 // From a File (e.g. drag-and-drop)
 const { rootBoard, boards, resources } = await loadOBZ(file);
 
-// Or from an ArrayBuffer (e.g. fetch response)
+// Or from anything else — ArrayBuffer, Blob, Node Buffer, etc.
 const parsed = await extractOBZ(buffer);
 ```
 
@@ -133,7 +130,7 @@ if (result.success) {
 
 ## API
 
-One naming convention covers the whole surface: `parse*` takes a JSON string, `validate*` takes an already-parsed object, `load*` takes a browser `File` (`loadBoard` also accepts an `ArrayBuffer`), `stringify*` returns a JSON string — and `extractOBZ`/`createOBZ` operate on whole archives.
+One naming convention covers the whole surface: `parse*` takes a JSON string, `validate*` takes an already-parsed object, `load*` takes a browser `File`, `stringify*` returns a JSON string — and `extractOBZ`/`loadBoard` also accept a `Blob`, `ArrayBuffer`, or typed-array view (e.g. a Node `Buffer`), for use outside the browser.
 
 ### OBF (single board)
 
@@ -146,18 +143,18 @@ One naming convention covers the whole surface: `parse*` takes a JSON string, `v
 
 ### OBZ (board package)
 
-| Function                                     | Returns              | Description                                                               |
-| -------------------------------------------- | -------------------- | ------------------------------------------------------------------------- |
-| `loadOBZ(file)`                              | `Promise<ParsedOBZ>` | Load an OBZ package from a browser `File`                                 |
-| `extractOBZ(archive)`                        | `Promise<ParsedOBZ>` | Extract boards, manifest, root board, and resources from an `ArrayBuffer` |
-| `createOBZ(boards, rootBoardId, resources?)` | `Promise<Blob>`      | Create an OBZ package as a `Blob`                                         |
-| `parseManifest(json)`                        | `OBFManifest`        | Parse a `manifest.json` string into a validated `OBFManifest`             |
+| Function                                     | Returns              | Description                                                                                                   |
+| -------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `loadOBZ(file)`                              | `Promise<ParsedOBZ>` | Load an OBZ package from a browser `File`                                                                     |
+| `extractOBZ(archive)`                        | `Promise<ParsedOBZ>` | Extract boards, manifest, root board, and resources from a `File`, `Blob`, `ArrayBuffer`, or typed-array view |
+| `createOBZ(boards, rootBoardId, resources?)` | `Promise<Blob>`      | Create an OBZ package as a `Blob`                                                                             |
+| `parseManifest(json)`                        | `OBFManifest`        | Parse a `manifest.json` string into a validated `OBFManifest`                                                 |
 
 ### Format detection
 
-| Function           | Returns                | Description                                                                                 |
-| ------------------ | ---------------------- | ------------------------------------------------------------------------------------------- |
-| `loadBoard(input)` | `Promise<LoadedBoard>` | Detect OBF vs OBZ from a `File` or `ArrayBuffer` and load it; returns a `LoadedBoard` union |
+| Function           | Returns                | Description                                                                                                            |
+| ------------------ | ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `loadBoard(input)` | `Promise<LoadedBoard>` | Detect OBF vs OBZ from a `File`, `Blob`, `ArrayBuffer`, or typed-array view and load it; returns a `LoadedBoard` union |
 
 ### Utilities
 
@@ -169,32 +166,33 @@ One naming convention covers the whole surface: `parse*` takes a JSON string, `v
 
 ### Types
 
-| Type                  | Description                                                                            |
-| --------------------- | -------------------------------------------------------------------------------------- |
-| `OBFBoard`            | A single communication board                                                           |
-| `OBFGrid`             | Grid layout (rows, columns, order)                                                     |
-| `OBFButton`           | A button on the board                                                                  |
-| `OBFButtonAction`     | Button action (spelling or specialty)                                                  |
-| `OBFSpellingAction`   | Spelling action (e.g., `+s`)                                                           |
-| `OBFSpecialtyAction`  | Specialty action (e.g., `:clear`)                                                      |
-| `OBFLoadBoard`        | Reference to load another board                                                        |
-| `OBFMedia`            | Common media properties (base for `OBFImage` and `OBFSound`)                           |
-| `OBFImage`            | An image resource (extends `OBFMedia`)                                                 |
-| `OBFSound`            | A sound resource (alias of `OBFMedia`)                                                 |
-| `OBFSymbolInfo`       | Symbol set reference                                                                   |
-| `OBFManifest`         | OBZ package manifest                                                                   |
-| `ParsedOBZ`           | Return type of `extractOBZ` / `loadOBZ` — `{ manifest, boards, rootBoard, resources }` |
-| `LoadedBoard`         | Return type of `loadBoard` — `{ format: "obz", archive } \| { format: "obf", board }`  |
-| `OBFID`               | Unique identifier (string, coerced from number)                                        |
-| `OBFFormatVersion`    | Format version string (e.g., `open-board-0.1`)                                         |
-| `OBFLicense`          | Licensing information                                                                  |
-| `OBFLocaleCode`       | BCP 47 locale code                                                                     |
-| `OBFLocalizedStrings` | Key-value string translations                                                          |
-| `OBFStrings`          | Multi-locale string translations                                                       |
+| Type                  | Description                                                                                 |
+| --------------------- | ------------------------------------------------------------------------------------------- |
+| `OBFBoard`            | A single communication board                                                                |
+| `OBFGrid`             | Grid layout (rows, columns, order)                                                          |
+| `OBFButton`           | A button on the board                                                                       |
+| `OBFButtonAction`     | Button action (spelling or specialty)                                                       |
+| `OBFSpellingAction`   | Spelling action (e.g., `+s`)                                                                |
+| `OBFSpecialtyAction`  | Specialty action (e.g., `:clear`)                                                           |
+| `OBFLoadBoard`        | Reference to load another board                                                             |
+| `OBFMedia`            | Common media properties (base for `OBFImage` and `OBFSound`)                                |
+| `OBFImage`            | An image resource (extends `OBFMedia`)                                                      |
+| `OBFSound`            | A sound resource (alias of `OBFMedia`)                                                      |
+| `OBFSymbolInfo`       | Symbol set reference                                                                        |
+| `OBFManifest`         | OBZ package manifest                                                                        |
+| `ParsedOBZ`           | Return type of `extractOBZ` / `loadOBZ` — `{ manifest, boards, rootBoard, resources }`      |
+| `LoadedBoard`         | Return type of `loadBoard` — `{ format: "obz", archive } \| { format: "obf", board }`       |
+| `BinaryInput`         | Input type of `loadBoard` / `extractOBZ` — `File \| Blob \| ArrayBuffer \| ArrayBufferView` |
+| `OBFID`               | Unique identifier (string, coerced from number)                                             |
+| `OBFFormatVersion`    | Format version string (e.g., `open-board-0.1`)                                              |
+| `OBFLicense`          | Licensing information                                                                       |
+| `OBFLocaleCode`       | BCP 47 locale code                                                                          |
+| `OBFLocalizedStrings` | Key-value string translations                                                               |
+| `OBFStrings`          | Multi-locale string translations                                                            |
 
 ### Schemas
 
-Every type above except `ParsedOBZ` and `LoadedBoard` is exported alongside a matching Zod schema with a `Schema` suffix — `OBFBoard` → `OBFBoardSchema`, `OBFManifest` → `OBFManifestSchema`, and so on. Import any of them to validate with `safeParse`/`parse` or to compose into your own schemas:
+Every type above except `ParsedOBZ`, `LoadedBoard`, and `BinaryInput` is exported alongside a matching Zod schema with a `Schema` suffix — `OBFBoard` → `OBFBoardSchema`, `OBFManifest` → `OBFManifestSchema`, and so on. Import any of them to validate with `safeParse`/`parse` or to compose into your own schemas:
 
 ```ts
 import { OBFButtonSchema, OBFManifestSchema } from "@shayc/open-board-format";

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,3 +62,4 @@ export type { LoadedBoard } from "./load-board";
 
 // ZIP helpers
 export { isZip, unzip, zip } from "./zip";
+export type { BinaryInput } from "./zip";

--- a/src/load-board.test.ts
+++ b/src/load-board.test.ts
@@ -40,11 +40,31 @@ describe("loadBoard", () => {
     );
   });
 
+  test("loads a single OBF board from a Blob", async () => {
+    const blob = new Blob([JSON.stringify(validBoard)]);
+
+    const loaded = await loadBoard(blob);
+
+    expect(loaded).toEqual({ format: "obf", board: validBoard });
+  });
+
   test("loads a single OBF board from an ArrayBuffer", async () => {
     const bytes = new TextEncoder().encode(JSON.stringify(validBoard));
     const buffer = bytes.buffer.slice(0, bytes.byteLength);
 
     const loaded = await loadBoard(buffer);
+
+    expect(loaded).toEqual({ format: "obf", board: validBoard });
+  });
+
+  test("loads a single OBF board from a Uint8Array view offset into a larger buffer", async () => {
+    const json = JSON.stringify(validBoard);
+    const bytes = new TextEncoder().encode(json);
+    const padded = new Uint8Array(bytes.byteLength + 10);
+    padded.set(bytes, 10);
+    const view = padded.subarray(10);
+
+    const loaded = await loadBoard(view);
 
     expect(loaded).toEqual({ format: "obf", board: validBoard });
   });

--- a/src/load-board.ts
+++ b/src/load-board.ts
@@ -6,7 +6,8 @@ import { parseOBF } from "./obf";
 import { extractOBZ } from "./obz";
 import type { ParsedOBZ } from "./obz";
 import type { OBFBoard } from "./schema";
-import { isZip } from "./zip";
+import { isZip, toArrayBuffer } from "./zip";
+import type { BinaryInput } from "./zip";
 
 /**
  * Result of {@link loadBoard} — a discriminated union over the two file
@@ -37,18 +38,16 @@ export type LoadedBoard =
  * or fetch response without inspecting the file extension or re-deriving the
  * OBF-vs-OBZ distinction themselves.
  *
- * @param input - A `File` handle or `ArrayBuffer` holding `.obf` or `.obz` content.
+ * @param input - A `File`, `Blob`, `ArrayBuffer`, or `ArrayBufferView`
+ *   (e.g. a Node `Buffer`) holding `.obf` or `.obz` content.
  * @returns A discriminated union tagged by `format`.
  *
  * @throws {@link OBFError} — the OBZ failures of {@link extractOBZ} when the
  *   input is an archive, or the OBF failures of {@link parseOBF} otherwise.
  *   Branch on `error.info.code`.
  */
-export async function loadBoard(
-  input: File | ArrayBuffer,
-): Promise<LoadedBoard> {
-  const buffer =
-    input instanceof ArrayBuffer ? input : await input.arrayBuffer();
+export async function loadBoard(input: BinaryInput): Promise<LoadedBoard> {
+  const buffer = await toArrayBuffer(input);
 
   if (isZip(buffer)) {
     return { format: "obz", archive: await extractOBZ(buffer) };

--- a/src/obz.test.ts
+++ b/src/obz.test.ts
@@ -317,12 +317,12 @@ describe("createOBZ", () => {
     ).toMatchObject({ code: "path-collision", path: "boards/b.obf" });
   });
 
-  test("omits sounds map when no sounds have paths", async () => {
+  test("includes empty images and sounds maps when neither have paths", async () => {
     const extracted = await extractOBZ(
       await (await createOBZ([makeBoard()], "b")).arrayBuffer(),
     );
 
-    expect(extracted.manifest.paths.sounds).toBeUndefined();
+    expect(extracted.manifest.paths.sounds).toEqual({});
     expect(extracted.manifest.paths.images).toEqual({});
   });
 

--- a/src/obz.test.ts
+++ b/src/obz.test.ts
@@ -420,11 +420,11 @@ describe("Integration: createOBZ and extractOBZ", () => {
     expect(extracted.boards.size).toBe(2);
 
     const extractedBoard1 = extracted.boards.get("board-1");
-    expect(extractedBoard1?.buttons[0].label).toBe("Go to 2");
-    expect(extractedBoard1?.buttons[0].load_board?.id).toBe("board-2");
+    expect(extractedBoard1?.buttons[0]?.label).toBe("Go to 2");
+    expect(extractedBoard1?.buttons[0]?.load_board?.id).toBe("board-2");
 
     const extractedBoard2 = extracted.boards.get("board-2");
-    expect(extractedBoard2?.buttons[0].label).toBe("Back");
+    expect(extractedBoard2?.buttons[0]?.label).toBe("Back");
   });
 });
 

--- a/src/obz.test.ts
+++ b/src/obz.test.ts
@@ -60,6 +60,16 @@ describe("extractOBZ", () => {
     });
   });
 
+  test("extracts a valid OBZ archive from a Uint8Array directly, with no ArrayBuffer conversion", async () => {
+    const helloBoard = makeBoard({ id: "test" });
+    const obzBlob = await createOBZ([helloBoard], "test");
+    const bytes = new Uint8Array(await obzBlob.arrayBuffer());
+
+    const result = await extractOBZ(bytes);
+
+    expect(result.rootBoard.id).toBe("test");
+  });
+
   test("throws for non-ZIP input", async () => {
     const notZip = new ArrayBuffer(10);
 

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -157,7 +157,7 @@ export async function createOBZ(
     paths: {
       boards: boardPaths,
       images: imagePaths,
-      ...(Object.keys(soundPaths).length > 0 ? { sounds: soundPaths } : {}),
+      sounds: soundPaths,
     },
   });
 

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -6,7 +6,8 @@ import { OBFError } from "./errors";
 import { parseOBF } from "./obf";
 import type { OBFBoard, OBFManifest } from "./schema";
 import { OBFBoardSchema, OBFManifestSchema } from "./schema";
-import { isZip, unzip, zip } from "./zip";
+import { isZip, toArrayBuffer, unzip, zip } from "./zip";
+import type { BinaryInput } from "./zip";
 
 /**
  * Fully extracted contents of an `.obz` archive.
@@ -32,8 +33,8 @@ export interface ParsedOBZ {
 /**
  * Read a `File` and extract its contents as a parsed OBZ package.
  *
- * This relies on the browser `File` API; for Node environments,
- * read the file to an `ArrayBuffer` and pass it to {@link extractOBZ} instead.
+ * A thin convenience wrapper — {@link extractOBZ} accepts a `File` directly,
+ * so this exists only for the naming symmetry with {@link loadOBF}.
  *
  * @param file - A `File` handle pointing to an `.obz` archive.
  * @returns The parsed manifest, boards, root board, and binary resources.
@@ -42,14 +43,14 @@ export interface ParsedOBZ {
  *   this delegates to.
  */
 export async function loadOBZ(file: File): Promise<ParsedOBZ> {
-  const archive = await file.arrayBuffer();
-  return extractOBZ(archive);
+  return extractOBZ(file);
 }
 
 /**
  * Decompress an OBZ archive and return its manifest, boards, and resources.
  *
- * @param archive - The OBZ archive as an `ArrayBuffer`.
+ * @param archive - The OBZ archive as a `File`, `Blob`, `ArrayBuffer`, or
+ *   `ArrayBufferView` (e.g. a Node `Buffer`).
  * @returns A {@link ParsedOBZ} with the archive's manifest, boards, root
  *          board, and resources.
  *
@@ -58,12 +59,14 @@ export async function loadOBZ(file: File): Promise<ParsedOBZ> {
  *   `"invalid-manifest"` (bad manifest), `"missing-board"`,
  *   `"board-id-mismatch"`, or `"invalid-board"` (a board fails validation).
  */
-export async function extractOBZ(archive: ArrayBuffer): Promise<ParsedOBZ> {
-  if (!isZip(archive)) {
+export async function extractOBZ(archive: BinaryInput): Promise<ParsedOBZ> {
+  const buffer = await toArrayBuffer(archive);
+
+  if (!isZip(buffer)) {
     throw new OBFError({ code: "not-zip" });
   }
 
-  const entries = await unzip(archive);
+  const entries = await unzip(buffer);
 
   const manifest = extractManifest(entries);
   const { boards, rootBoard } = extractBoards(manifest, entries);

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -194,8 +194,9 @@ export async function createOBZ(
         { cause: result.error },
       );
     }
+
     entries.set(
-      boardPaths[result.data.id],
+      boardPaths[board.id]!,
       encoder.encode(JSON.stringify(result.data, null, 2)),
     );
   }

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -428,10 +428,10 @@ describe("OBFGridSchema", () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.order[0][0]).toBe("1");
-      expect(result.data.order[0][1]).toBe("2");
-      expect(result.data.order[1][0]).toBe("3");
-      expect(result.data.order[1][1]).toBeNull();
+      expect(result.data.order[0]?.[0]).toBe("1");
+      expect(result.data.order[0]?.[1]).toBe("2");
+      expect(result.data.order[1]?.[0]).toBe("3");
+      expect(result.data.order[1]?.[1]).toBeNull();
     }
   });
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -240,9 +240,15 @@ export const OBFButtonSchema = z
     actions: z.array(OBFButtonActionSchema).optional(),
     /** Information to load another board when this button is activated. */
     load_board: OBFLoadBoardSchema.optional(),
-    /** Background color of the button in `rgb` or `rgba` format. */
+    /**
+     * Background color of the button, typically `rgb`/`rgba`. Not
+     * strictly validated — any string is accepted.
+     */
     background_color: z.string().optional(),
-    /** Border color of the button in `rgb` or `rgba` format. */
+    /**
+     * Border color of the button, typically `rgb`/`rgba`. Not strictly
+     * validated — any string is accepted.
+     */
     border_color: z.string().optional(),
     /** Vertical position for absolute positioning (0.0 to 1.0). */
     top: z.number().min(0).max(1).optional(),

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { expectOBFErrorAsync } from "./test-utils";
-import { isZip, unzip, zip } from "./zip";
+import { isZip, toArrayBuffer, unzip, zip } from "./zip";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -9,7 +9,7 @@ const decoder = new TextDecoder();
  * Helper to safely extract an ArrayBuffer from a Uint8Array,
  * avoiding typed-array .buffer footguns with offset/length mismatches.
  */
-function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+function bytesToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   return bytes.buffer.slice(
     bytes.byteOffset,
     bytes.byteOffset + bytes.byteLength,
@@ -53,7 +53,7 @@ describe("zip", () => {
     const files = new Map<string, Uint8Array>([["test.txt", testContent]]);
 
     const zipped = await zip(files);
-    const roundTripped = await unzip(toArrayBuffer(zipped));
+    const roundTripped = await unzip(bytesToArrayBuffer(zipped));
 
     expect(roundTripped.size).toBe(1);
     const bytes = roundTripped.get("test.txt");
@@ -72,7 +72,7 @@ describe("zip", () => {
     ]);
 
     const zipped = await zip(files);
-    const roundTripped = await unzip(toArrayBuffer(zipped));
+    const roundTripped = await unzip(bytesToArrayBuffer(zipped));
 
     expect(roundTripped.size).toBe(1);
     const bytes = roundTripped.get("from-arraybuffer.txt");
@@ -83,7 +83,7 @@ describe("zip", () => {
 
 describe("unzip", () => {
   test("rejects with an unreadable-zip OBFError for invalid data", async () => {
-    const invalidData = toArrayBuffer(
+    const invalidData = bytesToArrayBuffer(
       new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04]),
     );
 
@@ -99,9 +99,34 @@ describe("unzip", () => {
     ]);
 
     const zipped = await zip(files);
-    const unzipped = await unzip(toArrayBuffer(zipped));
+    const unzipped = await unzip(bytesToArrayBuffer(zipped));
 
     expect([...unzipped.keys()]).toEqual(["folder/file.txt"]);
+  });
+});
+
+describe("toArrayBuffer", () => {
+  test("returns an ArrayBuffer input unchanged", async () => {
+    const original = new Uint8Array([1, 2, 3]).buffer;
+
+    expect(await toArrayBuffer(original)).toBe(original);
+  });
+
+  test("slices a Uint8Array view to its own window, ignoring surrounding bytes", async () => {
+    const padded = new Uint8Array([0xff, 0xff, 1, 2, 3, 0xff]);
+    const view = padded.subarray(2, 5);
+
+    const result = await toArrayBuffer(view);
+
+    expect(new Uint8Array(result)).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  test("reads a Blob via its arrayBuffer() method", async () => {
+    const blob = new Blob([new Uint8Array([4, 5, 6])]);
+
+    const result = await toArrayBuffer(blob);
+
+    expect(new Uint8Array(result)).toEqual(new Uint8Array([4, 5, 6]));
   });
 });
 
@@ -114,7 +139,7 @@ describe("Integration: zip and unzip", () => {
     ]);
 
     const zipped = await zip(files);
-    const unzipped = await unzip(toArrayBuffer(zipped));
+    const unzipped = await unzip(bytesToArrayBuffer(zipped));
 
     expect(unzipped.size).toBe(files.size);
 

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -18,6 +18,35 @@ const ZIP_MAGIC = [0x50, 0x4b] as const;
 const COMPRESSION_LEVEL = 6;
 
 /**
+ * Anything this package accepts as binary board data: a raw buffer, any
+ * typed-array view into one (including Node's `Buffer`), or a `File`/`Blob`
+ * handle.
+ */
+export type BinaryInput = File | Blob | ArrayBuffer | ArrayBufferView;
+
+/**
+ * Normalize any {@link BinaryInput} shape into a plain `ArrayBuffer`.
+ *
+ * A view is sliced to its own window rather than returning `.buffer`
+ * directly, since a `Uint8Array`/`Buffer` may cover only part of a larger,
+ * possibly shared, underlying buffer.
+ */
+export async function toArrayBuffer(input: BinaryInput): Promise<ArrayBuffer> {
+  if (input instanceof ArrayBuffer) {
+    return input;
+  }
+
+  if (ArrayBuffer.isView(input)) {
+    return input.buffer.slice(
+      input.byteOffset,
+      input.byteOffset + input.byteLength,
+    ) as ArrayBuffer;
+  }
+
+  return input.arrayBuffer();
+}
+
+/**
  * Decompress a ZIP archive into a map of file paths to raw bytes.
  *
  * Directory entries (paths ending in `/`, which some tools write explicitly

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,9 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
   },
   "include": ["src", "tsdown.config.ts", "vitest.config.ts"]
 }


### PR DESCRIPTION
## Summary
- `createOBZ` always emits `paths.images`/`paths.sounds` in the generated manifest, even when empty, matching the spec's example
- `loadBoard` and `extractOBZ` now accept a `Blob` or any typed-array view (e.g. Node `Buffer`) in addition to `File`/`ArrayBuffer`
- Clarify docs that button color fields aren't strictly validated
- Enable `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes` in tsconfig, fixing the resulting undefined-index cases

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck` (tsc --noEmit)
- [x] `npm run test:coverage` (143 tests, 100% coverage)
- [x] `npm run build`