### PR TITLE
Add opt-in zip-bomb protection via UnzipOptions

### DIFF
--- a/.changeset/spicy-hoops-attack.md
+++ b/.changeset/spicy-hoops-attack.md
@@ -2,4 +2,4 @@
 "@shayc/open-board-format": minor
 ---
 
-Add opt-in zip-bomb protection: `loadBoard`, `loadOBZ`, `extractOBZ`, and `unzip` accept an optional `UnzipLimits` (`maxEntrySize`, `maxTotalOriginalSize`, `maxEntries`) checked against declared ZIP metadata before inflation. Exceeding a limit aborts extraction with a new `OBFError` code `"archive-too-large"`. No limits are applied by default; existing call sites are unaffected.
+Add opt-in zip-bomb protection: `loadBoard`, `loadOBZ`, `extractOBZ`, and `unzip` accept an optional `UnzipOptions` with a `limits` field (`maxEntrySize`, `maxTotalOriginalSize`, `maxEntries`), checked per entry against declared ZIP metadata, keeping allocation bounded by the caps. Exceeding a limit aborts extraction with a new `OBFError` code `"archive-too-large"`. No limits are applied by default; existing call sites are unaffected.

--- a/.changeset/spicy-hoops-attack.md
+++ b/.changeset/spicy-hoops-attack.md
@@ -1,0 +1,5 @@
+---
+"@shayc/open-board-format": minor
+---
+
+Add opt-in zip-bomb protection: `loadBoard`, `loadOBZ`, `extractOBZ`, and `unzip` accept an optional `UnzipLimits` (`maxEntrySize`, `maxTotalOriginalSize`, `maxEntries`) checked against declared ZIP metadata before inflation. Exceeding a limit aborts extraction with a new `OBFError` code `"archive-too-large"`. No limits are applied by default; existing call sites are unaffected.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ const { rootBoard, boards, resources } = await loadOBZ(file);
 const parsed = await extractOBZ(buffer);
 
 // Untrusted input? Cap declared uncompressed sizes (see Security)
-const guarded = await extractOBZ(buffer, { maxTotalOriginalSize: 500e6 });
+const guarded = await extractOBZ(buffer, {
+  limits: { maxTotalOriginalSize: 500e6 },
+});
 ```
 
 `rootBoard` is the package's home board — the one `manifest.root` points at, already resolved. `boards` is keyed by board ID and `resources` by archive path; the `manifest` is also returned if you need the raw table of contents.
@@ -148,24 +150,24 @@ One naming convention covers the whole surface: `parse*` takes a JSON string, `v
 
 | Function                                     | Returns              | Description                                                                                                   |
 | -------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `loadOBZ(file, limits?)`                     | `Promise<ParsedOBZ>` | Load an OBZ package from a browser `File`                                                                     |
-| `extractOBZ(archive, limits?)`               | `Promise<ParsedOBZ>` | Extract boards, manifest, root board, and resources from a `File`, `Blob`, `ArrayBuffer`, or typed-array view |
+| `loadOBZ(file, options?)`                    | `Promise<ParsedOBZ>` | Load an OBZ package from a browser `File`                                                                     |
+| `extractOBZ(archive, options?)`              | `Promise<ParsedOBZ>` | Extract boards, manifest, root board, and resources from a `File`, `Blob`, `ArrayBuffer`, or typed-array view |
 | `createOBZ(boards, rootBoardId, resources?)` | `Promise<Blob>`      | Create an OBZ package as a `Blob`                                                                             |
 | `parseManifest(json)`                        | `OBFManifest`        | Parse a `manifest.json` string into a validated `OBFManifest`                                                 |
 
 ### Format detection
 
-| Function                    | Returns                | Description                                                                                                            |
-| --------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `loadBoard(input, limits?)` | `Promise<LoadedBoard>` | Detect OBF vs OBZ from a `File`, `Blob`, `ArrayBuffer`, or typed-array view and load it; returns a `LoadedBoard` union |
+| Function                     | Returns                | Description                                                                                                            |
+| ---------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `loadBoard(input, options?)` | `Promise<LoadedBoard>` | Detect OBF vs OBZ from a `File`, `Blob`, `ArrayBuffer`, or typed-array view and load it; returns a `LoadedBoard` union |
 
 ### Utilities
 
-| Function                  | Returns                            | Description                                              |
-| ------------------------- | ---------------------------------- | -------------------------------------------------------- |
-| `isZip(archive)`          | `boolean`                          | Check if an `ArrayBuffer` starts with a ZIP magic number |
-| `zip(entries)`            | `Promise<Uint8Array>`              | Create a ZIP from a map of paths to buffers              |
-| `unzip(archive, limits?)` | `Promise<Map<string, Uint8Array>>` | Extract a ZIP into a map of paths to `Uint8Array`        |
+| Function                   | Returns                            | Description                                              |
+| -------------------------- | ---------------------------------- | -------------------------------------------------------- |
+| `isZip(archive)`           | `boolean`                          | Check if an `ArrayBuffer` starts with a ZIP magic number |
+| `zip(entries)`             | `Promise<Uint8Array>`              | Create a ZIP from a map of paths to buffers              |
+| `unzip(archive, options?)` | `Promise<Map<string, Uint8Array>>` | Extract a ZIP into a map of paths to `Uint8Array`        |
 
 ### Types
 
@@ -187,6 +189,7 @@ One naming convention covers the whole surface: `parse*` takes a JSON string, `v
 | `LoadedBoard`         | Return type of `loadBoard` — `{ format: "obz", archive } \| { format: "obf", board }`                          |
 | `BinaryInput`         | Input type of `loadBoard` / `extractOBZ` — `File \| Blob \| ArrayBuffer \| ArrayBufferView`                    |
 | `UnzipLimits`         | Optional extraction caps — `{ maxEntrySize?, maxTotalOriginalSize?, maxEntries? }` (see [Security](#security)) |
+| `UnzipOptions`        | Options for `unzip` / `extractOBZ` / `loadOBZ` / `loadBoard` — `{ limits?: UnzipLimits }`                      |
 | `OBFID`               | Unique identifier (string, coerced from number)                                                                |
 | `OBFFormatVersion`    | Format version string (e.g., `open-board-0.1`)                                                                 |
 | `OBFLicense`          | Licensing information                                                                                          |
@@ -196,7 +199,7 @@ One naming convention covers the whole surface: `parse*` takes a JSON string, `v
 
 ### Schemas
 
-Every type above except `ParsedOBZ`, `LoadedBoard`, `BinaryInput`, and `UnzipLimits` is exported alongside a matching Zod schema with a `Schema` suffix — `OBFBoard` → `OBFBoardSchema`, `OBFManifest` → `OBFManifestSchema`, and so on. Import any of them to validate with `safeParse`/`parse` or to compose into your own schemas:
+Every type above except `ParsedOBZ`, `LoadedBoard`, `BinaryInput`, `UnzipLimits`, and `UnzipOptions` is exported alongside a matching Zod schema with a `Schema` suffix — `OBFBoard` → `OBFBoardSchema`, `OBFManifest` → `OBFManifestSchema`, and so on. Import any of them to validate with `safeParse`/`parse` or to compose into your own schemas:
 
 ```ts
 import { OBFButtonSchema, OBFManifestSchema } from "@shayc/open-board-format";
@@ -261,17 +264,19 @@ The `code` values, grouped by what they describe:
 
 ## Security
 
-OBZ archives are untrusted input. To guard against zip bombs, pass `UnzipLimits` to `loadBoard` / `loadOBZ` / `extractOBZ` / `unzip`:
+OBZ archives are untrusted input. To guard against zip bombs, pass `limits` (via `UnzipOptions`) to `loadBoard` / `loadOBZ` / `extractOBZ` / `unzip`:
 
 ```ts
 const parsed = await extractOBZ(buffer, {
-  maxEntrySize: 100e6, // any single entry, in bytes
-  maxTotalOriginalSize: 500e6, // sum of all entries, in bytes
-  maxEntries: 10_000, // entry count, including directory entries
+  limits: {
+    maxEntrySize: 100e6, // any single entry, in bytes
+    maxTotalOriginalSize: 500e6, // sum of all entries, in bytes
+    maxEntries: 10_000, // entry count, including directory entries
+  },
 });
 ```
 
-Size limits are checked against the uncompressed sizes declared in the archive's ZIP metadata, before any inflation happens; `maxEntries` caps how many entries are processed at all. Exceeding a limit aborts extraction and rejects with an `OBFError` whose code is `archive-too-large` (`info` carries `limit`, the entry `path` that tripped it, and `maxBytes`/`declaredBytes` for the size limits or `maxEntries`/`entryCount` for the count). No limits are applied by default. A lying header can't force larger allocations — fflate allocates output buffers at exactly the declared size — so the declared-size caps bound memory use.
+Size limits are checked per entry against the uncompressed size declared in the archive's ZIP metadata, before that entry is inflated; `maxEntries` caps how many entries are processed at all. Entries accepted before a later entry trips a limit have already been inflated, but total allocation stays bounded by the caps. Exceeding a limit aborts extraction and rejects with an `OBFError` whose code is `archive-too-large` (`info` carries `limit`, the entry `path` that tripped it, and `maxBytes`/`declaredBytes` for the size limits or `maxEntries`/`entryCount` for the count). No limits are applied by default. A lying header can't force larger allocations — fflate allocates output buffers at exactly the declared size — so the declared-size caps bound memory use.
 
 Entry paths are not sanitized — if you write extracted resources to disk, validate paths yourself first to avoid directory traversal.
 
@@ -283,7 +288,7 @@ What this library deliberately does not do:
 
 - **No network I/O** — media referenced by `url` or `data_url` is not fetched; resolving external media is up to you.
 - **No rendering** — it parses and validates data; drawing boards and playing sounds belong to your app.
-- **No default extraction limits, no path sanitization** — size caps are opt-in via `UnzipLimits`; see [Security](#security) before writing archive contents to disk.
+- **No default extraction limits, no path sanitization** — size caps are opt-in via `UnzipOptions`; see [Security](#security) before writing archive contents to disk.
 - **No referential integrity checks** — a `grid.order` id with no matching button, or an `image_id`/`sound_id` with no matching image/sound, is not flagged. Resolving references is up to your rendering layer.
 
 ## Versioning

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ const { rootBoard, boards, resources } = await loadOBZ(file);
 
 // Or from anything else — ArrayBuffer, Blob, Node Buffer, etc.
 const parsed = await extractOBZ(buffer);
+
+// Untrusted input? Cap declared uncompressed sizes (see Security)
+const guarded = await extractOBZ(buffer, { maxTotalOriginalSize: 500e6 });
 ```
 
 `rootBoard` is the package's home board — the one `manifest.root` points at, already resolved. `boards` is keyed by board ID and `resources` by archive path; the `manifest` is also returned if you need the raw table of contents.
@@ -145,54 +148,55 @@ One naming convention covers the whole surface: `parse*` takes a JSON string, `v
 
 | Function                                     | Returns              | Description                                                                                                   |
 | -------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `loadOBZ(file)`                              | `Promise<ParsedOBZ>` | Load an OBZ package from a browser `File`                                                                     |
-| `extractOBZ(archive)`                        | `Promise<ParsedOBZ>` | Extract boards, manifest, root board, and resources from a `File`, `Blob`, `ArrayBuffer`, or typed-array view |
+| `loadOBZ(file, limits?)`                     | `Promise<ParsedOBZ>` | Load an OBZ package from a browser `File`                                                                     |
+| `extractOBZ(archive, limits?)`               | `Promise<ParsedOBZ>` | Extract boards, manifest, root board, and resources from a `File`, `Blob`, `ArrayBuffer`, or typed-array view |
 | `createOBZ(boards, rootBoardId, resources?)` | `Promise<Blob>`      | Create an OBZ package as a `Blob`                                                                             |
 | `parseManifest(json)`                        | `OBFManifest`        | Parse a `manifest.json` string into a validated `OBFManifest`                                                 |
 
 ### Format detection
 
-| Function           | Returns                | Description                                                                                                            |
-| ------------------ | ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `loadBoard(input)` | `Promise<LoadedBoard>` | Detect OBF vs OBZ from a `File`, `Blob`, `ArrayBuffer`, or typed-array view and load it; returns a `LoadedBoard` union |
+| Function                    | Returns                | Description                                                                                                            |
+| --------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `loadBoard(input, limits?)` | `Promise<LoadedBoard>` | Detect OBF vs OBZ from a `File`, `Blob`, `ArrayBuffer`, or typed-array view and load it; returns a `LoadedBoard` union |
 
 ### Utilities
 
-| Function         | Returns                            | Description                                              |
-| ---------------- | ---------------------------------- | -------------------------------------------------------- |
-| `isZip(archive)` | `boolean`                          | Check if an `ArrayBuffer` starts with a ZIP magic number |
-| `zip(entries)`   | `Promise<Uint8Array>`              | Create a ZIP from a map of paths to buffers              |
-| `unzip(archive)` | `Promise<Map<string, Uint8Array>>` | Extract a ZIP into a map of paths to `Uint8Array`        |
+| Function                  | Returns                            | Description                                              |
+| ------------------------- | ---------------------------------- | -------------------------------------------------------- |
+| `isZip(archive)`          | `boolean`                          | Check if an `ArrayBuffer` starts with a ZIP magic number |
+| `zip(entries)`            | `Promise<Uint8Array>`              | Create a ZIP from a map of paths to buffers              |
+| `unzip(archive, limits?)` | `Promise<Map<string, Uint8Array>>` | Extract a ZIP into a map of paths to `Uint8Array`        |
 
 ### Types
 
-| Type                  | Description                                                                                 |
-| --------------------- | ------------------------------------------------------------------------------------------- |
-| `OBFBoard`            | A single communication board                                                                |
-| `OBFGrid`             | Grid layout (rows, columns, order)                                                          |
-| `OBFButton`           | A button on the board                                                                       |
-| `OBFButtonAction`     | Button action (spelling or specialty)                                                       |
-| `OBFSpellingAction`   | Spelling action (e.g., `+s`)                                                                |
-| `OBFSpecialtyAction`  | Specialty action (e.g., `:clear`)                                                           |
-| `OBFLoadBoard`        | Reference to load another board                                                             |
-| `OBFMedia`            | Common media properties (base for `OBFImage` and `OBFSound`)                                |
-| `OBFImage`            | An image resource (extends `OBFMedia`)                                                      |
-| `OBFSound`            | A sound resource (alias of `OBFMedia`)                                                      |
-| `OBFSymbolInfo`       | Symbol set reference                                                                        |
-| `OBFManifest`         | OBZ package manifest                                                                        |
-| `ParsedOBZ`           | Return type of `extractOBZ` / `loadOBZ` — `{ manifest, boards, rootBoard, resources }`      |
-| `LoadedBoard`         | Return type of `loadBoard` — `{ format: "obz", archive } \| { format: "obf", board }`       |
-| `BinaryInput`         | Input type of `loadBoard` / `extractOBZ` — `File \| Blob \| ArrayBuffer \| ArrayBufferView` |
-| `OBFID`               | Unique identifier (string, coerced from number)                                             |
-| `OBFFormatVersion`    | Format version string (e.g., `open-board-0.1`)                                              |
-| `OBFLicense`          | Licensing information                                                                       |
-| `OBFLocaleCode`       | BCP 47 locale code                                                                          |
-| `OBFLocalizedStrings` | Key-value string translations                                                               |
-| `OBFStrings`          | Multi-locale string translations                                                            |
+| Type                  | Description                                                                                                    |
+| --------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `OBFBoard`            | A single communication board                                                                                   |
+| `OBFGrid`             | Grid layout (rows, columns, order)                                                                             |
+| `OBFButton`           | A button on the board                                                                                          |
+| `OBFButtonAction`     | Button action (spelling or specialty)                                                                          |
+| `OBFSpellingAction`   | Spelling action (e.g., `+s`)                                                                                   |
+| `OBFSpecialtyAction`  | Specialty action (e.g., `:clear`)                                                                              |
+| `OBFLoadBoard`        | Reference to load another board                                                                                |
+| `OBFMedia`            | Common media properties (base for `OBFImage` and `OBFSound`)                                                   |
+| `OBFImage`            | An image resource (extends `OBFMedia`)                                                                         |
+| `OBFSound`            | A sound resource (alias of `OBFMedia`)                                                                         |
+| `OBFSymbolInfo`       | Symbol set reference                                                                                           |
+| `OBFManifest`         | OBZ package manifest                                                                                           |
+| `ParsedOBZ`           | Return type of `extractOBZ` / `loadOBZ` — `{ manifest, boards, rootBoard, resources }`                         |
+| `LoadedBoard`         | Return type of `loadBoard` — `{ format: "obz", archive } \| { format: "obf", board }`                          |
+| `BinaryInput`         | Input type of `loadBoard` / `extractOBZ` — `File \| Blob \| ArrayBuffer \| ArrayBufferView`                    |
+| `UnzipLimits`         | Optional extraction caps — `{ maxEntrySize?, maxTotalOriginalSize?, maxEntries? }` (see [Security](#security)) |
+| `OBFID`               | Unique identifier (string, coerced from number)                                                                |
+| `OBFFormatVersion`    | Format version string (e.g., `open-board-0.1`)                                                                 |
+| `OBFLicense`          | Licensing information                                                                                          |
+| `OBFLocaleCode`       | BCP 47 locale code                                                                                             |
+| `OBFLocalizedStrings` | Key-value string translations                                                                                  |
+| `OBFStrings`          | Multi-locale string translations                                                                               |
 
 ### Schemas
 
-Every type above except `ParsedOBZ`, `LoadedBoard`, and `BinaryInput` is exported alongside a matching Zod schema with a `Schema` suffix — `OBFBoard` → `OBFBoardSchema`, `OBFManifest` → `OBFManifestSchema`, and so on. Import any of them to validate with `safeParse`/`parse` or to compose into your own schemas:
+Every type above except `ParsedOBZ`, `LoadedBoard`, `BinaryInput`, and `UnzipLimits` is exported alongside a matching Zod schema with a `Schema` suffix — `OBFBoard` → `OBFBoardSchema`, `OBFManifest` → `OBFManifestSchema`, and so on. Import any of them to validate with `safeParse`/`parse` or to compose into your own schemas:
 
 ```ts
 import { OBFButtonSchema, OBFManifestSchema } from "@shayc/open-board-format";
@@ -227,23 +231,24 @@ try {
 
 The `code` values, grouped by what they describe:
 
-| Group       | `info.code`         | Key fields (on `info`)           |
-| ----------- | ------------------- | -------------------------------- |
-| Decoding    | `not-json`          | `source`                         |
-|             | `not-zip`           | —                                |
-|             | `unreadable-zip`    | —                                |
-| Validation  | `invalid-board`     | `issues`, `boardId?`             |
-|             | `invalid-manifest`  | `issues`                         |
-| Read (OBZ)  | `missing-manifest`  | —                                |
-|             | `missing-board`     | `boardId`, `path`                |
-|             | `board-id-mismatch` | `path`, `declaredId`, `actualId` |
-| Write (OBZ) | `unknown-root`      | `rootBoardId`                    |
-|             | `duplicate-board`   | `boardId`                        |
-|             | `missing-resource`  | `kind`, `mediaId`, `path`        |
-|             | `conflicting-paths` | `kind`, `mediaId`, `paths`       |
-|             | `path-collision`    | `path`                           |
-|             | `zip-failed`        | —                                |
-| Internal    | `internal`          | `detail`                         |
+| Group       | `info.code`         | Key fields (on `info`)                        |
+| ----------- | ------------------- | --------------------------------------------- |
+| Decoding    | `not-json`          | `source`                                      |
+|             | `not-zip`           | —                                             |
+|             | `unreadable-zip`    | —                                             |
+|             | `archive-too-large` | `limit`, `path`, and the tripped cap's fields |
+| Validation  | `invalid-board`     | `issues`, `boardId?`                          |
+|             | `invalid-manifest`  | `issues`                                      |
+| Read (OBZ)  | `missing-manifest`  | —                                             |
+|             | `missing-board`     | `boardId`, `path`                             |
+|             | `board-id-mismatch` | `path`, `declaredId`, `actualId`              |
+| Write (OBZ) | `unknown-root`      | `rootBoardId`                                 |
+|             | `duplicate-board`   | `boardId`                                     |
+|             | `missing-resource`  | `kind`, `mediaId`, `path`                     |
+|             | `conflicting-paths` | `kind`, `mediaId`, `paths`                    |
+|             | `path-collision`    | `path`                                        |
+|             | `zip-failed`        | —                                             |
+| Internal    | `internal`          | `detail`                                      |
 
 `OBFErrorInfo` and `OBFErrorCode` are exported for exhaustive handling.
 
@@ -256,7 +261,19 @@ The `code` values, grouped by what they describe:
 
 ## Security
 
-OBZ archives are untrusted input. This library does not enforce limits on entry size or count, and does not sanitize entry paths — if you write extracted resources to disk, validate paths yourself first to avoid directory traversal. For stronger guarantees against zip-bomb-style payloads, run extraction in a sandboxed context (Web Worker, isolated process).
+OBZ archives are untrusted input. To guard against zip bombs, pass `UnzipLimits` to `loadBoard` / `loadOBZ` / `extractOBZ` / `unzip`:
+
+```ts
+const parsed = await extractOBZ(buffer, {
+  maxEntrySize: 100e6, // any single entry, in bytes
+  maxTotalOriginalSize: 500e6, // sum of all entries, in bytes
+  maxEntries: 10_000, // entry count, including directory entries
+});
+```
+
+Size limits are checked against the uncompressed sizes declared in the archive's ZIP metadata, before any inflation happens; `maxEntries` caps how many entries are processed at all. Exceeding a limit aborts extraction and rejects with an `OBFError` whose code is `archive-too-large` (`info` carries `limit`, the entry `path` that tripped it, and `maxBytes`/`declaredBytes` for the size limits or `maxEntries`/`entryCount` for the count). No limits are applied by default. A lying header can't force larger allocations — fflate allocates output buffers at exactly the declared size — so the declared-size caps bound memory use.
+
+Entry paths are not sanitized — if you write extracted resources to disk, validate paths yourself first to avoid directory traversal.
 
 Found a security issue? Open a private advisory at [github.com/shayc/open-board-format/security/advisories/new](https://github.com/shayc/open-board-format/security/advisories/new).
 
@@ -266,7 +283,7 @@ What this library deliberately does not do:
 
 - **No network I/O** — media referenced by `url` or `data_url` is not fetched; resolving external media is up to you.
 - **No rendering** — it parses and validates data; drawing boards and playing sounds belong to your app.
-- **No extraction limits or path sanitization** — see [Security](#security) before writing archive contents to disk.
+- **No default extraction limits, no path sanitization** — size caps are opt-in via `UnzipLimits`; see [Security](#security) before writing archive contents to disk.
 - **No referential integrity checks** — a `grid.order` id with no matching button, or an `image_id`/`sound_id` with no matching image/sound, is not flagged. Resolving references is up to your rendering layer.
 
 ## Versioning

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -59,6 +59,44 @@ describe("OBFError", () => {
     expect(error.cause).toBeInstanceOf(Error);
   });
 
+  test("derives a message for the archive-too-large maxEntries limit", () => {
+    const error = new OBFError({
+      code: "archive-too-large",
+      limit: "maxEntries",
+      maxEntries: 2,
+      entryCount: 3,
+      path: "sounds/extra.mp3",
+    });
+
+    expect(error.message).toBe(
+      'Invalid OBZ: entry count reached 3 at "sounds/extra.mp3", exceeding the 2-entry limit',
+    );
+  });
+
+  test("derives messages for the archive-too-large size limits", () => {
+    const entryError = new OBFError({
+      code: "archive-too-large",
+      limit: "maxEntrySize",
+      maxBytes: 50,
+      declaredBytes: 100,
+      path: "images/big.png",
+    });
+    expect(entryError.message).toBe(
+      'Invalid OBZ: entry "images/big.png" declares 100 bytes uncompressed, exceeding the 50-byte per-entry limit',
+    );
+
+    const totalError = new OBFError({
+      code: "archive-too-large",
+      limit: "maxTotalOriginalSize",
+      maxBytes: 100,
+      declaredBytes: 120,
+      path: "sounds/last.mp3",
+    });
+    expect(totalError.message).toBe(
+      'Invalid OBZ: declared uncompressed size reached 120 bytes at "sounds/last.mp3", exceeding the 100-byte total limit',
+    );
+  });
+
   test("derives a message for the internal variant from its detail", () => {
     const error = new OBFError(
       { code: "internal", detail: "generated manifest failed validation" },

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -50,6 +50,28 @@ export type OBFErrorInfo =
   | { code: "not-zip" }
   /** A ZIP archive could not be decompressed. */
   | { code: "unreadable-zip" }
+  /** An entry or the archive's declared uncompressed total exceeds a caller-supplied limit. */
+  | {
+      code: "archive-too-large";
+      limit: "maxEntrySize" | "maxTotalOriginalSize";
+      /** The cap that was exceeded, in bytes. */
+      maxBytes: number;
+      /** The declared size that exceeded it: the entry's size, or the running total. */
+      declaredBytes: number;
+      /** The archive entry whose declaration tripped the limit. */
+      path: string;
+    }
+  /** The archive has more entries than a caller-supplied limit allows. */
+  | {
+      code: "archive-too-large";
+      limit: "maxEntries";
+      /** The cap that was exceeded, as an entry count. */
+      maxEntries: number;
+      /** The running entry count that exceeded it. */
+      entryCount: number;
+      /** The archive entry that tripped the limit. */
+      path: string;
+    }
   // --- validation (underlying `ZodError` on `error.cause`) ---
   /** A board failed schema validation. `boardId` is set when known. */
   | { code: "invalid-board"; boardId?: string; issues: readonly OBFIssue[] }
@@ -123,6 +145,12 @@ function formatOBFError(info: OBFErrorInfo): string {
       return "Invalid OBZ: not a ZIP file";
     case "unreadable-zip":
       return "ZIP archive could not be read";
+    case "archive-too-large":
+      return info.limit === "maxEntries"
+        ? `Invalid OBZ: entry count reached ${info.entryCount} at "${info.path}", exceeding the ${info.maxEntries}-entry limit`
+        : info.limit === "maxEntrySize"
+          ? `Invalid OBZ: entry "${info.path}" declares ${info.declaredBytes} bytes uncompressed, exceeding the ${info.maxBytes}-byte per-entry limit`
+          : `Invalid OBZ: declared uncompressed size reached ${info.declaredBytes} bytes at "${info.path}", exceeding the ${info.maxBytes}-byte total limit`;
     case "invalid-board": {
       const subject = info.boardId ? `board "${info.boardId}"` : "board";
       return `Invalid OBF ${subject}:\n${prettifyIssues(info.issues)}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,4 +62,4 @@ export type { LoadedBoard } from "./load-board";
 
 // ZIP helpers
 export { isZip, unzip, zip } from "./zip";
-export type { BinaryInput, UnzipLimits } from "./zip";
+export type { BinaryInput, UnzipLimits, UnzipOptions } from "./zip";

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,4 +62,4 @@ export type { LoadedBoard } from "./load-board";
 
 // ZIP helpers
 export { isZip, unzip, zip } from "./zip";
-export type { BinaryInput } from "./zip";
+export type { BinaryInput, UnzipLimits } from "./zip";

--- a/src/load-board.test.ts
+++ b/src/load-board.test.ts
@@ -104,6 +104,29 @@ describe("loadBoard", () => {
     expect(loaded.archive.rootBoard.id).toBe("lots_of_stuff");
   });
 
+  test("passes limits through when the input is an OBZ archive", async () => {
+    const obzBlob = await createOBZ([validBoard], "test-board");
+    const file = new File([obzBlob], "test.obz");
+
+    const info = await expectOBFErrorAsync(
+      loadBoard(file, { maxTotalOriginalSize: 10 }),
+    );
+    expect(info.code).toBe("archive-too-large");
+
+    const loaded = await loadBoard(file, {
+      maxTotalOriginalSize: Number.MAX_SAFE_INTEGER,
+    });
+    expect(loaded.format).toBe("obz");
+  });
+
+  test("ignores limits for plain OBF input", async () => {
+    const file = new File([JSON.stringify(validBoard)], "test.obf");
+
+    const loaded = await loadBoard(file, { maxTotalOriginalSize: 1 });
+
+    expect(loaded).toEqual({ format: "obf", board: validBoard });
+  });
+
   test("surfaces the OBZ extractor's error for a ZIP missing its manifest", async () => {
     // A real ZIP so isZip passes and we exercise the OBZ branch, not the OBF one.
     const zipped = await zip(

--- a/src/load-board.test.ts
+++ b/src/load-board.test.ts
@@ -109,12 +109,12 @@ describe("loadBoard", () => {
     const file = new File([obzBlob], "test.obz");
 
     const info = await expectOBFErrorAsync(
-      loadBoard(file, { maxTotalOriginalSize: 10 }),
+      loadBoard(file, { limits: { maxTotalOriginalSize: 10 } }),
     );
     expect(info.code).toBe("archive-too-large");
 
     const loaded = await loadBoard(file, {
-      maxTotalOriginalSize: Number.MAX_SAFE_INTEGER,
+      limits: { maxTotalOriginalSize: Number.MAX_SAFE_INTEGER },
     });
     expect(loaded.format).toBe("obz");
   });
@@ -122,7 +122,9 @@ describe("loadBoard", () => {
   test("ignores limits for plain OBF input", async () => {
     const file = new File([JSON.stringify(validBoard)], "test.obf");
 
-    const loaded = await loadBoard(file, { maxTotalOriginalSize: 1 });
+    const loaded = await loadBoard(file, {
+      limits: { maxTotalOriginalSize: 1 },
+    });
 
     expect(loaded).toEqual({ format: "obf", board: validBoard });
   });

--- a/src/load-board.ts
+++ b/src/load-board.ts
@@ -3,11 +3,11 @@
  */
 
 import { parseOBF } from "./obf";
-import { extractOBZ } from "./obz";
 import type { ParsedOBZ } from "./obz";
+import { extractOBZ } from "./obz";
 import type { OBFBoard } from "./schema";
+import type { BinaryInput, UnzipLimits } from "./zip";
 import { isZip, toArrayBuffer } from "./zip";
-import type { BinaryInput } from "./zip";
 
 /**
  * Result of {@link loadBoard} — a discriminated union over the two file
@@ -40,17 +40,22 @@ export type LoadedBoard =
  *
  * @param input - A `File`, `Blob`, `ArrayBuffer`, or `ArrayBufferView`
  *   (e.g. a Node `Buffer`) holding `.obf` or `.obz` content.
+ * @param limits - Optional {@link UnzipLimits} on declared uncompressed sizes.
+ *   Applies only when the input is an OBZ archive; ignored for `.obf` JSON.
  * @returns A discriminated union tagged by `format`.
  *
  * @throws {@link OBFError} — the OBZ failures of {@link extractOBZ} when the
  *   input is an archive, or the OBF failures of {@link parseOBF} otherwise.
  *   Branch on `error.info.code`.
  */
-export async function loadBoard(input: BinaryInput): Promise<LoadedBoard> {
+export async function loadBoard(
+  input: BinaryInput,
+  limits?: UnzipLimits,
+): Promise<LoadedBoard> {
   const buffer = await toArrayBuffer(input);
 
   if (isZip(buffer)) {
-    return { format: "obz", archive: await extractOBZ(buffer) };
+    return { format: "obz", archive: await extractOBZ(buffer, limits) };
   }
 
   return { format: "obf", board: parseOBF(new TextDecoder().decode(buffer)) };

--- a/src/load-board.ts
+++ b/src/load-board.ts
@@ -47,6 +47,8 @@ export type LoadedBoard =
  * @throws {@link OBFError} — the OBZ failures of {@link extractOBZ} when the
  *   input is an archive, or the OBF failures of {@link parseOBF} otherwise.
  *   Branch on `error.info.code`.
+ * @throws {@link TypeError} if a limit in `options.limits` is `NaN` and the
+ *   input is an OBZ archive.
  */
 export async function loadBoard(
   input: BinaryInput,

--- a/src/load-board.ts
+++ b/src/load-board.ts
@@ -6,7 +6,7 @@ import { parseOBF } from "./obf";
 import type { ParsedOBZ } from "./obz";
 import { extractOBZ } from "./obz";
 import type { OBFBoard } from "./schema";
-import type { BinaryInput, UnzipLimits } from "./zip";
+import type { BinaryInput, UnzipOptions } from "./zip";
 import { isZip, toArrayBuffer } from "./zip";
 
 /**
@@ -40,8 +40,8 @@ export type LoadedBoard =
  *
  * @param input - A `File`, `Blob`, `ArrayBuffer`, or `ArrayBufferView`
  *   (e.g. a Node `Buffer`) holding `.obf` or `.obz` content.
- * @param limits - Optional {@link UnzipLimits} on declared uncompressed sizes.
- *   Applies only when the input is an OBZ archive; ignored for `.obf` JSON.
+ * @param options - Optional {@link UnzipOptions}. Applies only when the input
+ *   is an OBZ archive; ignored for `.obf` JSON.
  * @returns A discriminated union tagged by `format`.
  *
  * @throws {@link OBFError} — the OBZ failures of {@link extractOBZ} when the
@@ -50,12 +50,12 @@ export type LoadedBoard =
  */
 export async function loadBoard(
   input: BinaryInput,
-  limits?: UnzipLimits,
+  options?: UnzipOptions,
 ): Promise<LoadedBoard> {
   const buffer = await toArrayBuffer(input);
 
   if (isZip(buffer)) {
-    return { format: "obz", archive: await extractOBZ(buffer, limits) };
+    return { format: "obz", archive: await extractOBZ(buffer, options) };
   }
 
   return { format: "obf", board: parseOBF(new TextDecoder().decode(buffer)) };

--- a/src/obz.test.ts
+++ b/src/obz.test.ts
@@ -176,6 +176,32 @@ describe("extractOBZ", () => {
       actualId: "a",
     });
   });
+
+  test("rejects with archive-too-large when limits are exceeded", async () => {
+    const obzBlob = await createOBZ([makeBoard({ id: "test" })], "test");
+
+    const info = await expectOBFErrorAsync(
+      extractOBZ(await obzBlob.arrayBuffer(), { maxTotalOriginalSize: 10 }),
+    );
+
+    expect(info.code).toBe("archive-too-large");
+  });
+
+  test("extracts the same archive with generous limits as without", async () => {
+    const obzBlob = await createOBZ([makeBoard({ id: "test" })], "test");
+    const buffer = await obzBlob.arrayBuffer();
+
+    const limited = await extractOBZ(buffer, {
+      maxEntrySize: Number.MAX_SAFE_INTEGER,
+      maxTotalOriginalSize: Number.MAX_SAFE_INTEGER,
+    });
+    const unlimited = await extractOBZ(buffer);
+
+    expect(limited.manifest).toEqual(unlimited.manifest);
+    expect(limited.boards).toEqual(unlimited.boards);
+    expect(limited.rootBoard).toEqual(unlimited.rootBoard);
+    expect(limited.resources).toEqual(unlimited.resources);
+  });
 });
 
 describe("loadOBZ", () => {
@@ -188,6 +214,17 @@ describe("loadOBZ", () => {
     expect(result.manifest.root).toBe("boards/test.obf");
     expect(result.boards.get("test")).toBeDefined();
     expect(result.rootBoard.id).toBe("test");
+  });
+
+  test("passes limits through to extraction", async () => {
+    const obzBlob = await createOBZ([makeBoard({ id: "test" })], "test");
+    const file = new File([obzBlob], "test.obz", { type: "application/zip" });
+
+    const info = await expectOBFErrorAsync(
+      loadOBZ(file, { maxTotalOriginalSize: 10 }),
+    );
+
+    expect(info.code).toBe("archive-too-large");
   });
 });
 

--- a/src/obz.test.ts
+++ b/src/obz.test.ts
@@ -181,7 +181,9 @@ describe("extractOBZ", () => {
     const obzBlob = await createOBZ([makeBoard({ id: "test" })], "test");
 
     const info = await expectOBFErrorAsync(
-      extractOBZ(await obzBlob.arrayBuffer(), { maxTotalOriginalSize: 10 }),
+      extractOBZ(await obzBlob.arrayBuffer(), {
+        limits: { maxTotalOriginalSize: 10 },
+      }),
     );
 
     expect(info.code).toBe("archive-too-large");
@@ -192,8 +194,10 @@ describe("extractOBZ", () => {
     const buffer = await obzBlob.arrayBuffer();
 
     const limited = await extractOBZ(buffer, {
-      maxEntrySize: Number.MAX_SAFE_INTEGER,
-      maxTotalOriginalSize: Number.MAX_SAFE_INTEGER,
+      limits: {
+        maxEntrySize: Number.MAX_SAFE_INTEGER,
+        maxTotalOriginalSize: Number.MAX_SAFE_INTEGER,
+      },
     });
     const unlimited = await extractOBZ(buffer);
 
@@ -221,7 +225,7 @@ describe("loadOBZ", () => {
     const file = new File([obzBlob], "test.obz", { type: "application/zip" });
 
     const info = await expectOBFErrorAsync(
-      loadOBZ(file, { maxTotalOriginalSize: 10 }),
+      loadOBZ(file, { limits: { maxTotalOriginalSize: 10 } }),
     );
 
     expect(info.code).toBe("archive-too-large");

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -6,8 +6,8 @@ import { OBFError } from "./errors";
 import { parseOBF } from "./obf";
 import type { OBFBoard, OBFManifest } from "./schema";
 import { OBFBoardSchema, OBFManifestSchema } from "./schema";
+import type { BinaryInput, UnzipLimits } from "./zip";
 import { isZip, toArrayBuffer, unzip, zip } from "./zip";
-import type { BinaryInput } from "./zip";
 
 /**
  * Fully extracted contents of an `.obz` archive.
@@ -37,13 +37,17 @@ export interface ParsedOBZ {
  * so this exists only for the naming symmetry with {@link loadOBF}.
  *
  * @param file - A `File` handle pointing to an `.obz` archive.
+ * @param limits - Optional {@link UnzipLimits} on declared uncompressed sizes.
  * @returns The parsed manifest, boards, root board, and binary resources.
  *
  * @throws {@link OBFError} — the same failures as {@link extractOBZ}, which
  *   this delegates to.
  */
-export async function loadOBZ(file: File): Promise<ParsedOBZ> {
-  return extractOBZ(file);
+export async function loadOBZ(
+  file: File,
+  limits?: UnzipLimits,
+): Promise<ParsedOBZ> {
+  return extractOBZ(file, limits);
 }
 
 /**
@@ -51,22 +55,28 @@ export async function loadOBZ(file: File): Promise<ParsedOBZ> {
  *
  * @param archive - The OBZ archive as a `File`, `Blob`, `ArrayBuffer`, or
  *   `ArrayBufferView` (e.g. a Node `Buffer`).
+ * @param limits - Optional {@link UnzipLimits} on declared uncompressed sizes,
+ *   checked before inflation. No limits are applied by default.
  * @returns A {@link ParsedOBZ} with the archive's manifest, boards, root
  *          board, and resources.
  *
  * @throws {@link OBFError}; branch on `info.code`: `"not-zip"`,
- *   `"unreadable-zip"`, `"missing-manifest"`, `"not-json"` or
- *   `"invalid-manifest"` (bad manifest), `"missing-board"`,
- *   `"board-id-mismatch"`, or `"invalid-board"` (a board fails validation).
+ *   `"unreadable-zip"`, `"archive-too-large"` (a limit in `limits` is
+ *   exceeded), `"missing-manifest"`, `"not-json"` or `"invalid-manifest"`
+ *   (bad manifest), `"missing-board"`, `"board-id-mismatch"`, or
+ *   `"invalid-board"` (a board fails validation).
  */
-export async function extractOBZ(archive: BinaryInput): Promise<ParsedOBZ> {
+export async function extractOBZ(
+  archive: BinaryInput,
+  limits?: UnzipLimits,
+): Promise<ParsedOBZ> {
   const buffer = await toArrayBuffer(archive);
 
   if (!isZip(buffer)) {
     throw new OBFError({ code: "not-zip" });
   }
 
-  const entries = await unzip(buffer);
+  const entries = await unzip(buffer, limits);
 
   const manifest = extractManifest(entries);
   const { boards, rootBoard } = extractBoards(manifest, entries);

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -6,7 +6,7 @@ import { OBFError } from "./errors";
 import { parseOBF } from "./obf";
 import type { OBFBoard, OBFManifest } from "./schema";
 import { OBFBoardSchema, OBFManifestSchema } from "./schema";
-import type { BinaryInput, UnzipLimits } from "./zip";
+import type { BinaryInput, UnzipOptions } from "./zip";
 import { isZip, toArrayBuffer, unzip, zip } from "./zip";
 
 /**
@@ -37,7 +37,7 @@ export interface ParsedOBZ {
  * so this exists only for the naming symmetry with {@link loadOBF}.
  *
  * @param file - A `File` handle pointing to an `.obz` archive.
- * @param limits - Optional {@link UnzipLimits} on declared uncompressed sizes.
+ * @param options - Optional {@link UnzipOptions} on declared uncompressed sizes.
  * @returns The parsed manifest, boards, root board, and binary resources.
  *
  * @throws {@link OBFError} — the same failures as {@link extractOBZ}, which
@@ -45,9 +45,9 @@ export interface ParsedOBZ {
  */
 export async function loadOBZ(
   file: File,
-  limits?: UnzipLimits,
+  options?: UnzipOptions,
 ): Promise<ParsedOBZ> {
-  return extractOBZ(file, limits);
+  return extractOBZ(file, options);
 }
 
 /**
@@ -55,20 +55,21 @@ export async function loadOBZ(
  *
  * @param archive - The OBZ archive as a `File`, `Blob`, `ArrayBuffer`, or
  *   `ArrayBufferView` (e.g. a Node `Buffer`).
- * @param limits - Optional {@link UnzipLimits} on declared uncompressed sizes,
- *   checked before inflation. No limits are applied by default.
+ * @param options - Optional {@link UnzipOptions}. `options.limits` caps
+ *   declared uncompressed sizes, checked before inflation. No limits are
+ *   applied by default.
  * @returns A {@link ParsedOBZ} with the archive's manifest, boards, root
  *          board, and resources.
  *
  * @throws {@link OBFError}; branch on `info.code`: `"not-zip"`,
- *   `"unreadable-zip"`, `"archive-too-large"` (a limit in `limits` is
+ *   `"unreadable-zip"`, `"archive-too-large"` (a limit in `options.limits` is
  *   exceeded), `"missing-manifest"`, `"not-json"` or `"invalid-manifest"`
  *   (bad manifest), `"missing-board"`, `"board-id-mismatch"`, or
  *   `"invalid-board"` (a board fails validation).
  */
 export async function extractOBZ(
   archive: BinaryInput,
-  limits?: UnzipLimits,
+  options?: UnzipOptions,
 ): Promise<ParsedOBZ> {
   const buffer = await toArrayBuffer(archive);
 
@@ -76,7 +77,7 @@ export async function extractOBZ(
     throw new OBFError({ code: "not-zip" });
   }
 
-  const entries = await unzip(buffer, limits);
+  const entries = await unzip(buffer, options);
 
   const manifest = extractManifest(entries);
   const { boards, rootBoard } = extractBoards(manifest, entries);

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -42,6 +42,7 @@ export interface ParsedOBZ {
  *
  * @throws {@link OBFError} — the same failures as {@link extractOBZ}, which
  *   this delegates to.
+ * @throws {@link TypeError} if a limit in `options.limits` is `NaN`.
  */
 export async function loadOBZ(
   file: File,
@@ -66,6 +67,7 @@ export async function loadOBZ(
  *   exceeded), `"missing-manifest"`, `"not-json"` or `"invalid-manifest"`
  *   (bad manifest), `"missing-board"`, `"board-id-mismatch"`, or
  *   `"invalid-board"` (a board fails validation).
+ * @throws {@link TypeError} if a limit in `options.limits` is `NaN`.
  */
 export async function extractOBZ(
   archive: BinaryInput,

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -109,22 +109,24 @@ describe("unzip limits", () => {
   const filesOf = (...sizes: number[]) =>
     new Map(sizes.map((size, i) => [`file-${i}.bin`, new Uint8Array(size)]));
 
-  test("no limits, empty limits, and undefined limits behave identically", async () => {
+  test("no options, empty options, empty limits, and undefined options behave identically", async () => {
     const zipped = await zip(filesOf(10, 20));
     const buffer = bytesToArrayBuffer(zipped);
 
     const bare = await unzip(buffer);
-    const empty = await unzip(buffer, {});
+    const emptyOptions = await unzip(buffer, {});
+    const emptyLimits = await unzip(buffer, { limits: {} });
     const explicit = await unzip(buffer, undefined);
 
-    expect(empty).toEqual(bare);
+    expect(emptyOptions).toEqual(bare);
+    expect(emptyLimits).toEqual(bare);
     expect(explicit).toEqual(bare);
   });
 
   test("rejects when an entry's declared size exceeds maxEntrySize", async () => {
     const zipped = await zip(filesOf(100));
     const info = await expectOBFErrorAsync(
-      unzip(bytesToArrayBuffer(zipped), { maxEntrySize: 50 }),
+      unzip(bytesToArrayBuffer(zipped), { limits: { maxEntrySize: 50 } }),
     );
 
     expect(info).toEqual({
@@ -139,7 +141,7 @@ describe("unzip limits", () => {
   test("passes when an entry's declared size equals maxEntrySize exactly", async () => {
     const zipped = await zip(filesOf(50));
     const unzipped = await unzip(bytesToArrayBuffer(zipped), {
-      maxEntrySize: 50,
+      limits: { maxEntrySize: 50 },
     });
 
     expect(unzipped.get("file-0.bin")).toEqual(new Uint8Array(50));
@@ -148,7 +150,9 @@ describe("unzip limits", () => {
   test("rejects when the running total exceeds maxTotalOriginalSize", async () => {
     const zipped = await zip(filesOf(40, 40, 40));
     const info = await expectOBFErrorAsync(
-      unzip(bytesToArrayBuffer(zipped), { maxTotalOriginalSize: 100 }),
+      unzip(bytesToArrayBuffer(zipped), {
+        limits: { maxTotalOriginalSize: 100 },
+      }),
     );
 
     expect(info).toEqual({
@@ -163,7 +167,7 @@ describe("unzip limits", () => {
   test("passes when the total declared size equals maxTotalOriginalSize exactly", async () => {
     const zipped = await zip(filesOf(40, 40, 40));
     const unzipped = await unzip(bytesToArrayBuffer(zipped), {
-      maxTotalOriginalSize: 120,
+      limits: { maxTotalOriginalSize: 120 },
     });
 
     expect(unzipped.size).toBe(3);
@@ -172,7 +176,7 @@ describe("unzip limits", () => {
   test("rejects when the entry count exceeds maxEntries", async () => {
     const zipped = await zip(filesOf(10, 10, 10));
     const info = await expectOBFErrorAsync(
-      unzip(bytesToArrayBuffer(zipped), { maxEntries: 2 }),
+      unzip(bytesToArrayBuffer(zipped), { limits: { maxEntries: 2 } }),
     );
 
     expect(info).toEqual({
@@ -187,7 +191,7 @@ describe("unzip limits", () => {
   test("passes when the entry count equals maxEntries exactly", async () => {
     const zipped = await zip(filesOf(10, 10, 10));
     const unzipped = await unzip(bytesToArrayBuffer(zipped), {
-      maxEntries: 3,
+      limits: { maxEntries: 3 },
     });
 
     expect(unzipped.size).toBe(3);
@@ -200,7 +204,7 @@ describe("unzip limits", () => {
     ]);
     const zipped = await zip(files);
     const info = await expectOBFErrorAsync(
-      unzip(bytesToArrayBuffer(zipped), { maxEntries: 1 }),
+      unzip(bytesToArrayBuffer(zipped), { limits: { maxEntries: 1 } }),
     );
 
     expect(info).toMatchObject({
@@ -211,12 +215,12 @@ describe("unzip limits", () => {
   });
 
   test("rejects promptly when a limit trips after a large entry started inflating asynchronously", async () => {
-    // 600,000 zero bytes: above fflate's 512 KB threshold and highly
-    // compressible, so it dispatches an async inflate worker that the
-    // limit-trip path must terminate.
+    // 600,000 zeros: over fflate's 512 KB sync-inflate threshold, so an async worker is dispatched.
     const zipped = await zip(filesOf(600_000, 100));
     const info = await expectOBFErrorAsync(
-      unzip(bytesToArrayBuffer(zipped), { maxTotalOriginalSize: 600_050 }),
+      unzip(bytesToArrayBuffer(zipped), {
+        limits: { maxTotalOriginalSize: 600_050 },
+      }),
     );
 
     expect(info).toMatchObject({
@@ -231,11 +235,46 @@ describe("unzip limits", () => {
     const buffer = bytesToArrayBuffer(zipped);
 
     const withLimits = await unzip(buffer, {
-      maxEntrySize: Number.MAX_SAFE_INTEGER,
-      maxTotalOriginalSize: Number.MAX_SAFE_INTEGER,
+      limits: {
+        maxEntrySize: Number.MAX_SAFE_INTEGER,
+        maxTotalOriginalSize: Number.MAX_SAFE_INTEGER,
+      },
     });
 
     expect(withLimits).toEqual(await unzip(buffer));
+  });
+
+  test.each(["maxEntrySize", "maxTotalOriginalSize", "maxEntries"] as const)(
+    "throws TypeError synchronously when %s is NaN",
+    (key) => {
+      const buffer = new ArrayBuffer(0);
+
+      expect(() => unzip(buffer, { limits: { [key]: NaN } })).toThrow(
+        new TypeError(`limits.${key} must not be NaN`),
+      );
+    },
+  );
+
+  test("rejects with unreadable-zip, not archive-too-large, when a corrupt entry precedes a limit trip", async () => {
+    const zipped = await zip(filesOf(1_000, 200_000));
+    const buffer = bytesToArrayBuffer(zipped);
+    const bytes = new Uint8Array(buffer);
+    const view = new DataView(buffer);
+
+    // Local header: "PK\x03\x04" at offset 0; name length (u16 LE) at 26, extra length at 28;
+    // entry 1's compressed data starts right after the header + name + extra.
+    const dataStart = 30 + view.getUint16(26, true) + view.getUint16(28, true);
+    bytes.fill(0xff, dataStart + 2, dataStart + 10);
+
+    // Sanity control: without limits, the corruption alone causes unreadable-zip.
+    expect((await expectOBFErrorAsync(unzip(buffer))).code).toBe(
+      "unreadable-zip",
+    );
+
+    const info = await expectOBFErrorAsync(
+      unzip(buffer, { limits: { maxTotalOriginalSize: 150_000 } }),
+    );
+    expect(info.code).toBe("unreadable-zip");
   });
 });
 

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -105,6 +105,140 @@ describe("unzip", () => {
   });
 });
 
+describe("unzip limits", () => {
+  const filesOf = (...sizes: number[]) =>
+    new Map(sizes.map((size, i) => [`file-${i}.bin`, new Uint8Array(size)]));
+
+  test("no limits, empty limits, and undefined limits behave identically", async () => {
+    const zipped = await zip(filesOf(10, 20));
+    const buffer = bytesToArrayBuffer(zipped);
+
+    const bare = await unzip(buffer);
+    const empty = await unzip(buffer, {});
+    const explicit = await unzip(buffer, undefined);
+
+    expect(empty).toEqual(bare);
+    expect(explicit).toEqual(bare);
+  });
+
+  test("rejects when an entry's declared size exceeds maxEntrySize", async () => {
+    const zipped = await zip(filesOf(100));
+    const info = await expectOBFErrorAsync(
+      unzip(bytesToArrayBuffer(zipped), { maxEntrySize: 50 }),
+    );
+
+    expect(info).toEqual({
+      code: "archive-too-large",
+      limit: "maxEntrySize",
+      maxBytes: 50,
+      declaredBytes: 100,
+      path: "file-0.bin",
+    });
+  });
+
+  test("passes when an entry's declared size equals maxEntrySize exactly", async () => {
+    const zipped = await zip(filesOf(50));
+    const unzipped = await unzip(bytesToArrayBuffer(zipped), {
+      maxEntrySize: 50,
+    });
+
+    expect(unzipped.get("file-0.bin")).toEqual(new Uint8Array(50));
+  });
+
+  test("rejects when the running total exceeds maxTotalOriginalSize", async () => {
+    const zipped = await zip(filesOf(40, 40, 40));
+    const info = await expectOBFErrorAsync(
+      unzip(bytesToArrayBuffer(zipped), { maxTotalOriginalSize: 100 }),
+    );
+
+    expect(info).toEqual({
+      code: "archive-too-large",
+      limit: "maxTotalOriginalSize",
+      maxBytes: 100,
+      declaredBytes: 120,
+      path: "file-2.bin",
+    });
+  });
+
+  test("passes when the total declared size equals maxTotalOriginalSize exactly", async () => {
+    const zipped = await zip(filesOf(40, 40, 40));
+    const unzipped = await unzip(bytesToArrayBuffer(zipped), {
+      maxTotalOriginalSize: 120,
+    });
+
+    expect(unzipped.size).toBe(3);
+  });
+
+  test("rejects when the entry count exceeds maxEntries", async () => {
+    const zipped = await zip(filesOf(10, 10, 10));
+    const info = await expectOBFErrorAsync(
+      unzip(bytesToArrayBuffer(zipped), { maxEntries: 2 }),
+    );
+
+    expect(info).toEqual({
+      code: "archive-too-large",
+      limit: "maxEntries",
+      maxEntries: 2,
+      entryCount: 3,
+      path: "file-2.bin",
+    });
+  });
+
+  test("passes when the entry count equals maxEntries exactly", async () => {
+    const zipped = await zip(filesOf(10, 10, 10));
+    const unzipped = await unzip(bytesToArrayBuffer(zipped), {
+      maxEntries: 3,
+    });
+
+    expect(unzipped.size).toBe(3);
+  });
+
+  test("counts directory entries toward maxEntries", async () => {
+    const files = new Map<string, Uint8Array>([
+      ["folder/", new Uint8Array(0)],
+      ["folder/file.txt", encoder.encode("content")],
+    ]);
+    const zipped = await zip(files);
+    const info = await expectOBFErrorAsync(
+      unzip(bytesToArrayBuffer(zipped), { maxEntries: 1 }),
+    );
+
+    expect(info).toMatchObject({
+      code: "archive-too-large",
+      limit: "maxEntries",
+      entryCount: 2,
+    });
+  });
+
+  test("rejects promptly when a limit trips after a large entry started inflating asynchronously", async () => {
+    // 600,000 zero bytes: above fflate's 512 KB threshold and highly
+    // compressible, so it dispatches an async inflate worker that the
+    // limit-trip path must terminate.
+    const zipped = await zip(filesOf(600_000, 100));
+    const info = await expectOBFErrorAsync(
+      unzip(bytesToArrayBuffer(zipped), { maxTotalOriginalSize: 600_050 }),
+    );
+
+    expect(info).toMatchObject({
+      code: "archive-too-large",
+      limit: "maxTotalOriginalSize",
+      path: "file-1.bin",
+    });
+  });
+
+  test("generous limits produce the same result as no limits", async () => {
+    const zipped = await zip(filesOf(10, 600_000));
+    const buffer = bytesToArrayBuffer(zipped);
+
+    const withLimits = await unzip(buffer, {
+      maxEntrySize: Number.MAX_SAFE_INTEGER,
+      maxTotalOriginalSize: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(withLimits).toEqual(await unzip(buffer));
+  });
+});
+
 describe("toArrayBuffer", () => {
   test("returns an ArrayBuffer input unchanged", async () => {
     const original = new Uint8Array([1, 2, 3]).buffer;

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -255,14 +255,14 @@ describe("unzip limits", () => {
     },
   );
 
-  test("rejects with unreadable-zip, not archive-too-large, when a corrupt entry precedes a limit trip", async () => {
+  test("rejects with unreadable-zip, not archive-too-large, when a synchronously-inflated corrupt entry precedes a limit trip", async () => {
+    // Both entries stay under fflate's 512 KB sync-inflate threshold; see the terminate() comment in unzip() for the async case this doesn't cover.
     const zipped = await zip(filesOf(1_000, 200_000));
     const buffer = bytesToArrayBuffer(zipped);
     const bytes = new Uint8Array(buffer);
     const view = new DataView(buffer);
 
-    // Local header: "PK\x03\x04" at offset 0; name length (u16 LE) at 26, extra length at 28;
-    // entry 1's compressed data starts right after the header + name + extra.
+    // Local header offsets: name length (u16 LE) at 26, extra length at 28.
     const dataStart = 30 + view.getUint16(26, true) + view.getUint16(28, true);
     bytes.fill(0xff, dataStart + 2, dataStart + 10);
 

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -2,6 +2,7 @@
  * Minimal ZIP helpers over fflate: signature sniffing, unzip, and zip.
  */
 
+import type { UnzipFileInfo } from "fflate";
 import { unzip as fflateUnzip, zip as fflateZip } from "fflate";
 import { OBFError } from "./errors";
 
@@ -47,6 +48,21 @@ export async function toArrayBuffer(input: BinaryInput): Promise<ArrayBuffer> {
 }
 
 /**
+ * Optional caps on declared uncompressed sizes, checked before inflation.
+ *
+ * The declared sizes come from the archive's ZIP metadata, so oversized input
+ * is rejected before any decompression work or output allocation happens.
+ */
+export interface UnzipLimits {
+  /** Max declared uncompressed size of any single entry, in bytes. */
+  maxEntrySize?: number;
+  /** Max sum of declared uncompressed sizes across all entries, in bytes. */
+  maxTotalOriginalSize?: number;
+  /** Max number of entries, counting directory entries the archive declares. */
+  maxEntries?: number;
+}
+
+/**
  * Decompress a ZIP archive into a map of file paths to raw bytes.
  *
  * Directory entries (paths ending in `/`, which some tools write explicitly
@@ -54,27 +70,105 @@ export async function toArrayBuffer(input: BinaryInput): Promise<ArrayBuffer> {
  * and this map is documented as file paths to bytes.
  *
  * @param archive - The ZIP archive as an `ArrayBuffer`.
+ * @param limits - Optional {@link UnzipLimits} checked against declared
+ *   (metadata) sizes before inflation. No limits are applied by default.
  * @returns A map of file paths to their decompressed content.
  *
  * @throws {@link OBFError} with `info.code` `"unreadable-zip"` if the archive is
- *   corrupt or cannot be decompressed.
+ *   corrupt or cannot be decompressed, or `"archive-too-large"` if a limit in
+ *   `limits` is exceeded.
  */
-export function unzip(archive: ArrayBuffer): Promise<Map<string, Uint8Array>> {
+export function unzip(
+  archive: ArrayBuffer,
+  limits?: UnzipLimits,
+): Promise<Map<string, Uint8Array>> {
   return new Promise((resolve, reject) => {
     const compressed = new Uint8Array(archive);
+    const { maxEntrySize, maxTotalOriginalSize, maxEntries } = limits ?? {};
 
-    fflateUnzip(compressed, (error, entries) => {
-      if (error) {
-        reject(new OBFError({ code: "unreadable-zip" }, { cause: error }));
-        return;
+    let limitError: OBFError | undefined;
+    let settled = false;
+    let totalDeclared = 0;
+    let entryCount = 0;
+
+    const filter = (file: UnzipFileInfo): boolean => {
+      if (limitError) {
+        return false; // limit tripped: skip the rest cheaply
       }
 
-      const pathToBytes = new Map(
-        Object.entries(entries).filter(([path]) => !path.endsWith("/")),
-      );
+      entryCount += 1;
+      if (maxEntries !== undefined && entryCount > maxEntries) {
+        limitError = new OBFError({
+          code: "archive-too-large",
+          limit: "maxEntries",
+          maxEntries,
+          entryCount,
+          path: file.name,
+        });
+        return false;
+      }
 
-      resolve(pathToBytes);
-    });
+      if (maxEntrySize !== undefined && file.originalSize > maxEntrySize) {
+        limitError = new OBFError({
+          code: "archive-too-large",
+          limit: "maxEntrySize",
+          maxBytes: maxEntrySize,
+          declaredBytes: file.originalSize,
+          path: file.name,
+        });
+        return false;
+      }
+
+      totalDeclared += file.originalSize;
+      if (
+        maxTotalOriginalSize !== undefined &&
+        totalDeclared > maxTotalOriginalSize
+      ) {
+        limitError = new OBFError({
+          code: "archive-too-large",
+          limit: "maxTotalOriginalSize",
+          maxBytes: maxTotalOriginalSize,
+          declaredBytes: totalDeclared,
+          path: file.name,
+        });
+        return false;
+      }
+
+      return true;
+    };
+
+    const terminate = fflateUnzip(
+      compressed,
+      limits ? { filter } : {},
+      (error, entries) => {
+        // After a limit trips, fflate still fires this with partial entries
+        // on a later microtask — the settled guard makes that a no-op.
+        if (settled) {
+          return;
+        }
+        settled = true;
+
+        if (error) {
+          reject(new OBFError({ code: "unreadable-zip" }, { cause: error }));
+          return;
+        }
+
+        const pathToBytes = new Map(
+          Object.entries(entries).filter(([path]) => !path.endsWith("/")),
+        );
+
+        resolve(pathToBytes);
+      },
+    );
+
+    // fflate runs every filter call synchronously inside fflateUnzip and
+    // defers its callback to a microtask, so limitError is final here and
+    // nothing can have settled yet.
+    if (limitError) {
+      settled = true;
+      terminate(); // kill any dispatched async inflate workers
+      reject(limitError);
+    }
   });
 }
 

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -186,6 +186,7 @@ export function unzip(
 
     if (limitError) {
       const error = limitError;
+      // Deliberate: this can pre-empt an in-flight entry's own corruption error, surfacing archive-too-large instead of unreadable-zip.
       terminate(); // kill any dispatched async inflate workers
       // Deferred so an archive error fflate queued during its sync pass settles first.
       queueMicrotask(() => {

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -48,10 +48,10 @@ export async function toArrayBuffer(input: BinaryInput): Promise<ArrayBuffer> {
 }
 
 /**
- * Optional caps on declared uncompressed sizes, checked before inflation.
- *
- * The declared sizes come from the archive's ZIP metadata, so oversized input
- * is rejected before any decompression work or output allocation happens.
+ * Optional caps on declared uncompressed sizes, checked per entry against the
+ * archive's ZIP metadata before that entry is inflated. Entries accepted
+ * before a later entry trips a limit have already been inflated, but total
+ * allocation stays bounded by the caps.
  */
 export interface UnzipLimits {
   /** Max declared uncompressed size of any single entry, in bytes. */
@@ -62,6 +62,12 @@ export interface UnzipLimits {
   maxEntries?: number;
 }
 
+/** Options for {@link unzip} and the OBZ loaders that delegate to it. */
+export interface UnzipOptions {
+  /** Optional {@link UnzipLimits} enforced during extraction. */
+  limits?: UnzipLimits;
+}
+
 /**
  * Decompress a ZIP archive into a map of file paths to raw bytes.
  *
@@ -70,21 +76,35 @@ export interface UnzipLimits {
  * and this map is documented as file paths to bytes.
  *
  * @param archive - The ZIP archive as an `ArrayBuffer`.
- * @param limits - Optional {@link UnzipLimits} checked against declared
- *   (metadata) sizes before inflation. No limits are applied by default.
+ * @param options - Optional {@link UnzipOptions}. `options.limits` is checked
+ *   per entry against declared (metadata) sizes before that entry is
+ *   inflated. No limits are applied by default.
  * @returns A map of file paths to their decompressed content.
  *
  * @throws {@link OBFError} with `info.code` `"unreadable-zip"` if the archive is
  *   corrupt or cannot be decompressed, or `"archive-too-large"` if a limit in
- *   `limits` is exceeded.
+ *   `options.limits` is exceeded.
+ * @throws {@link TypeError} if a limit in `options.limits` is `NaN`.
  */
 export function unzip(
   archive: ArrayBuffer,
-  limits?: UnzipLimits,
+  options?: UnzipOptions,
 ): Promise<Map<string, Uint8Array>> {
+  for (const key of [
+    "maxEntrySize",
+    "maxTotalOriginalSize",
+    "maxEntries",
+  ] as const) {
+    const value = options?.limits?.[key];
+    if (value !== undefined && Number.isNaN(value)) {
+      throw new TypeError(`limits.${key} must not be NaN`);
+    }
+  }
+
   return new Promise((resolve, reject) => {
     const compressed = new Uint8Array(archive);
-    const { maxEntrySize, maxTotalOriginalSize, maxEntries } = limits ?? {};
+    const { maxEntrySize, maxTotalOriginalSize, maxEntries } =
+      options?.limits ?? {};
 
     let limitError: OBFError | undefined;
     let settled = false;
@@ -139,10 +159,8 @@ export function unzip(
 
     const terminate = fflateUnzip(
       compressed,
-      limits ? { filter } : {},
+      options?.limits ? { filter } : {},
       (error, entries) => {
-        // After a limit trips, fflate still fires this with partial entries
-        // on a later microtask — the settled guard makes that a no-op.
         if (settled) {
           return;
         }
@@ -150,6 +168,11 @@ export function unzip(
 
         if (error) {
           reject(new OBFError({ code: "unreadable-zip" }, { cause: error }));
+          return;
+        }
+
+        if (limitError) {
+          reject(limitError);
           return;
         }
 
@@ -161,13 +184,16 @@ export function unzip(
       },
     );
 
-    // fflate runs every filter call synchronously inside fflateUnzip and
-    // defers its callback to a microtask, so limitError is final here and
-    // nothing can have settled yet.
     if (limitError) {
-      settled = true;
+      const error = limitError;
       terminate(); // kill any dispatched async inflate workers
-      reject(limitError);
+      // Deferred so an archive error fflate queued during its sync pass settles first.
+      queueMicrotask(() => {
+        if (!settled) {
+          settled = true;
+          reject(error);
+        }
+      });
     }
   });
 }


### PR DESCRIPTION
## Summary
- `loadBoard`, `loadOBZ`, `extractOBZ`, and `unzip` now accept an optional `UnzipOptions` bag (`{ limits?: UnzipLimits }`, with `maxEntrySize` / `maxTotalOriginalSize` / `maxEntries`) — a bag instead of a bare positional param, so future options (e.g. an `AbortSignal`) don't require another signature change
- Limits are checked per entry against declared ZIP metadata before that entry is inflated; entries accepted before a later entry trips a limit have already been inflated, but total allocation stays bounded by the caps (fflate allocates output at exactly the declared size)
- A `NaN` limit value throws a synchronous `TypeError` naming the field, instead of silently disabling protection (a bare `> NaN` comparison is always false)
- Exceeding a limit throws `OBFError` with the new `"archive-too-large"` code
- Fixed a race where a corrupt entry's error could be swallowed by a limit-trip rejection when both settle synchronously (the completion callback now re-checks the tripped limit rather than relying on fflate's undocumented callback timing). This doesn't extend to an entry large enough to trigger fflate's async inflate worker: terminating that worker on a limit trip is what bounds time/memory on the rejected archive, but it also means we never learn whether that entry was itself corrupt — `archive-too-large` wins over `unreadable-zip` there by design, documented at the `terminate()` call site in `unzip`
- No limits are applied by default; existing call sites are unaffected

## Test plan
- [x] `npm test` — 164 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean