### PR TITLE
Bound grid rows/columns (max 100)

### DIFF
--- a/.changeset/bound-grid-dimensions.md
+++ b/.changeset/bound-grid-dimensions.md
@@ -1,0 +1,5 @@
+---
+"@shayc/open-board-format": minor
+---
+
+Bound grid rows/columns (max 100)

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -490,7 +490,9 @@ describe("OBFGridSchema", () => {
     const validGrid = {
       rows: 100,
       columns: 100,
-      order: Array.from({ length: 100 }, () => Array(100).fill(null)),
+      order: Array.from({ length: 100 }, () =>
+        Array.from({ length: 100 }, () => null),
+      ),
     };
 
     expect(OBFGridSchema.safeParse(validGrid).success).toBe(true);

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -473,6 +473,28 @@ describe("OBFGridSchema", () => {
 
     expect(OBFGridSchema.safeParse(mismatchedColumns).success).toBe(false);
   });
+
+  test("rejects rows above the maximum", () => {
+    const hostileGrid = { rows: 1e9, columns: 1, order: [] };
+
+    expect(OBFGridSchema.safeParse(hostileGrid).success).toBe(false);
+  });
+
+  test("rejects columns above the maximum", () => {
+    const hostileGrid = { rows: 1, columns: 1e9, order: [] };
+
+    expect(OBFGridSchema.safeParse(hostileGrid).success).toBe(false);
+  });
+
+  test("accepts a large but sane grid at the maximum", () => {
+    const validGrid = {
+      rows: 100,
+      columns: 100,
+      order: Array.from({ length: 100 }, () => Array(100).fill(null)),
+    };
+
+    expect(OBFGridSchema.safeParse(validGrid).success).toBe(true);
+  });
 });
 
 describe("OBFBoardSchema", () => {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -278,12 +278,21 @@ export type OBFButton = z.infer<typeof OBFButtonSchema>;
 /**
  * Row-and-column layout that arranges buttons by their IDs.
  */
+/**
+ * Upper bound on grid dimensions. A board only needs these to lay out cells;
+ * a consumer allocates rows × columns, so an unbounded value (e.g. 1e9) would
+ * exhaust memory. 100 is generous headroom over any real AAC board (~15–20)
+ * and caps the hostile worst case at 100 × 100 cells.
+ */
+const MAX_GRID_ROWS = 100;
+const MAX_GRID_COLUMNS = 100;
+
 export const OBFGridSchema = z
   .looseObject({
     /** Number of rows in the grid. */
-    rows: z.number().int().min(1),
+    rows: z.number().int().min(1).max(MAX_GRID_ROWS),
     /** Number of columns in the grid. */
-    columns: z.number().int().min(1),
+    columns: z.number().int().min(1).max(MAX_GRID_COLUMNS),
     /**
      * 2D array representing the order of buttons by their IDs.
      * Each sub-array corresponds to a row, and each element is a button ID or null for empty slots.


### PR DESCRIPTION
## Summary
A malformed or malicious `.obf` can declare `grid.rows`/`grid.columns` like `1e9`. A consumer allocates rows × columns cells to lay out the board, so an unbounded value exhausts memory (tab OOM). This rejects such boards at parse time by capping both dimensions at 100 in `OBFGridSchema` — pure format validation, so it belongs in the schema.

100 is generous headroom over any real AAC board (~15–20) and caps the hostile worst case at 100 × 100 cells.

## Changes
- `src/schema.ts` — add `MAX_GRID_ROWS`/`MAX_GRID_COLUMNS` (100) and apply `.max()` to `rows`/`columns`
- `src/schema.test.ts` — reject oversized rows/columns; accept a well-formed 100×100 grid at the boundary
- Changeset (minor) — publishes via the changesets release workflow on merge

## Verification
`npm run lint && npm run typecheck && npm test` → 167 passing; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)