### PR TITLE
Trim redundant tests

### DIFF
--- a/.changeset/forty-teams-chew.md
+++ b/.changeset/forty-teams-chew.md
@@ -1,0 +1,4 @@
+---
+---
+
+Trim redundant tests. Test-only change — no package is bumped because nothing consumer-visible changed.

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -6,9 +6,10 @@ import { parseManifest } from "./obz";
 import { expectOBFError } from "./test-utils";
 
 /**
- * Switching on `info.code` narrows to each variant's fields with no casts.
- * The `default` arm is reachable as a real union, and adding a new variant to
- * `OBFErrorInfo` without handling it here would be a compile error.
+ * Stands in for consumer code: switching on `info.code` narrows to each
+ * variant's fields with no casts, and the `default` arm still has a usable
+ * `info.code`. Exhaustiveness is enforced in `formatOBFError`, not here — the
+ * `default` arm below absorbs any variant added later.
  */
 function summarize(info: OBFErrorInfo): string {
   switch (info.code) {
@@ -59,43 +60,56 @@ describe("OBFError", () => {
     expect(error.cause).toBeInstanceOf(Error);
   });
 
-  test("derives a message for the archive-too-large maxEntries limit", () => {
-    const error = new OBFError({
-      code: "archive-too-large",
-      limit: "maxEntries",
-      maxEntries: 2,
-      entryCount: 3,
-      path: "sounds/extra.mp3",
-    });
+  /**
+   * Each `archive-too-large` limit gets its own message branch. Messages are
+   * explicitly not part of the stable contract, so assert that the branch names
+   * the numbers and path a reader needs — not its exact wording. The `info`
+   * payloads are pinned exactly in zip.test.ts.
+   */
+  test.each([
+    [
+      "maxEntries",
+      {
+        code: "archive-too-large",
+        limit: "maxEntries",
+        maxEntries: 2,
+        entryCount: 3,
+        path: "sounds/extra.mp3",
+      },
+      ["3", "2", "sounds/extra.mp3"],
+    ],
+    [
+      "maxEntrySize",
+      {
+        code: "archive-too-large",
+        limit: "maxEntrySize",
+        maxBytes: 50,
+        declaredBytes: 100,
+        path: "images/big.png",
+      },
+      ["100", "50", "images/big.png"],
+    ],
+    [
+      "maxTotalOriginalSize",
+      {
+        code: "archive-too-large",
+        limit: "maxTotalOriginalSize",
+        maxBytes: 100,
+        declaredBytes: 120,
+        path: "sounds/last.mp3",
+      },
+      ["120", "100", "sounds/last.mp3"],
+    ],
+  ] as const)(
+    "derives a message for the archive-too-large %s limit",
+    (_limit, info, expected) => {
+      const { message } = new OBFError(info);
 
-    expect(error.message).toBe(
-      'Invalid OBZ: entry count reached 3 at "sounds/extra.mp3", exceeding the 2-entry limit',
-    );
-  });
-
-  test("derives messages for the archive-too-large size limits", () => {
-    const entryError = new OBFError({
-      code: "archive-too-large",
-      limit: "maxEntrySize",
-      maxBytes: 50,
-      declaredBytes: 100,
-      path: "images/big.png",
-    });
-    expect(entryError.message).toBe(
-      'Invalid OBZ: entry "images/big.png" declares 100 bytes uncompressed, exceeding the 50-byte per-entry limit',
-    );
-
-    const totalError = new OBFError({
-      code: "archive-too-large",
-      limit: "maxTotalOriginalSize",
-      maxBytes: 100,
-      declaredBytes: 120,
-      path: "sounds/last.mp3",
-    });
-    expect(totalError.message).toBe(
-      'Invalid OBZ: declared uncompressed size reached 120 bytes at "sounds/last.mp3", exceeding the 100-byte total limit',
-    );
-  });
+      for (const fragment of expected) {
+        expect(message).toContain(fragment);
+      }
+    },
+  );
 
   test("derives a message for the internal variant from its detail", () => {
     const error = new OBFError(

--- a/src/obz.test.ts
+++ b/src/obz.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "vitest";
 import { createOBZ, extractOBZ, loadOBZ, parseManifest } from "./obz";
 import type { OBFBoard } from "./schema";
 import {
-  expectOBFError,
   expectOBFErrorAsync,
   makeBoard,
   readFixtureArrayBuffer,
@@ -22,18 +21,6 @@ describe("parseManifest", () => {
     expect(manifest.format).toBe("open-board-0.1");
     expect(manifest.root).toBe("boards/test.obf");
     expect(manifest.paths.boards.test).toBe("boards/test.obf");
-  });
-
-  test("throws when root is not listed in paths.boards", () => {
-    const rootNotListed = JSON.stringify({
-      format: "open-board-0.1",
-      root: "boards/ghost.obf",
-      paths: { boards: { test: "boards/test.obf" }, images: {} },
-    });
-
-    expect(expectOBFError(() => parseManifest(rootNotListed)).code).toBe(
-      "invalid-manifest",
-    );
   });
 });
 
@@ -208,26 +195,20 @@ describe("extractOBZ", () => {
   });
 });
 
+// A one-line wrapper over extractOBZ: all it can get wrong is the File read or
+// dropping `options`, so both are asserted here and the rest is extractOBZ's.
 describe("loadOBZ", () => {
-  test("loads OBZ package from File object", async () => {
+  test("reads a File and forwards limits to extraction", async () => {
     const obzBlob = await createOBZ([makeBoard({ id: "test" })], "test");
     const file = new File([obzBlob], "test.obz", { type: "application/zip" });
 
     const result = await loadOBZ(file);
-
     expect(result.manifest.root).toBe("boards/test.obf");
-    expect(result.boards.get("test")).toBeDefined();
     expect(result.rootBoard.id).toBe("test");
-  });
-
-  test("passes limits through to extraction", async () => {
-    const obzBlob = await createOBZ([makeBoard({ id: "test" })], "test");
-    const file = new File([obzBlob], "test.obz", { type: "application/zip" });
 
     const info = await expectOBFErrorAsync(
       loadOBZ(file, { limits: { maxTotalOriginalSize: 10 } }),
     );
-
     expect(info.code).toBe("archive-too-large");
   });
 });

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -167,42 +167,13 @@ describe("OBFLicenseSchema", () => {
 });
 
 describe("OBFMediaSchema", () => {
-  test("accepts valid media with URL", () => {
-    const validMedia = {
-      id: "img1",
-      url: "https://example.com/image.png",
-      content_type: "image/png",
-    };
-
-    expect(OBFMediaSchema.safeParse(validMedia).success).toBe(true);
-  });
-
-  test("accepts valid media with data URI", () => {
-    const validMedia = {
-      id: "img2",
-      data: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==",
-      content_type: "image/png",
-    };
-
-    expect(OBFMediaSchema.safeParse(validMedia).success).toBe(true);
-  });
-
-  test("accepts valid media with path", () => {
-    const validMedia = {
-      id: "img3",
-      path: "images/icon.png",
-      content_type: "image/png",
-    };
-
-    expect(OBFMediaSchema.safeParse(validMedia).success).toBe(true);
-  });
-
-  test("accepts valid media with data_url", () => {
-    const validMedia = {
-      id: "img4",
-      data_url: "https://example.com/api/image",
-      content_type: "image/png",
-    };
+  test.each([
+    ["url", { url: "https://example.com/image.png" }],
+    ["data URI", { data: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==" }],
+    ["path", { path: "images/icon.png" }],
+    ["data_url", { data_url: "https://example.com/api/image" }],
+  ])("accepts media referenced by %s", (_label, reference) => {
+    const validMedia = { id: "img", content_type: "image/png", ...reference };
 
     expect(OBFMediaSchema.safeParse(validMedia).success).toBe(true);
   });
@@ -241,31 +212,17 @@ describe("OBFSymbolInfoSchema", () => {
 });
 
 describe("OBFImageSchema", () => {
-  test("accepts valid image with symbol info", () => {
-    const validImage = {
+  test("extends media with optional symbol and dimensions", () => {
+    const withSymbol = {
       id: "img1",
-      symbol: {
-        set: "symbolstix",
-        filename: "happy.png",
-      },
+      symbol: { set: "symbolstix", filename: "happy.png" },
       width: 300,
       height: 300,
       content_type: "image/png",
     };
 
-    expect(OBFImageSchema.safeParse(validImage).success).toBe(true);
-  });
-
-  test("accepts valid image without symbol info", () => {
-    const validImage = {
-      id: "img2",
-      url: "https://example.com/image.png",
-      width: 200,
-      height: 200,
-      content_type: "image/png",
-    };
-
-    expect(OBFImageSchema.safeParse(validImage).success).toBe(true);
+    expect(OBFImageSchema.safeParse(withSymbol).success).toBe(true);
+    expect(OBFImageSchema.safeParse({ id: "img2" }).success).toBe(true);
   });
 });
 
@@ -286,12 +243,15 @@ describe("OBFButtonSchema", () => {
     expect(OBFButtonSchema.safeParse(missingId).success).toBe(false);
   });
 
-  test("rejects button with invalid action", () => {
-    const emptyAction = { id: "1", action: ":" };
-    const plainString = { id: "1", action: "hello" };
-
-    expect(OBFButtonSchema.safeParse(emptyAction).success).toBe(false);
-    expect(OBFButtonSchema.safeParse(plainString).success).toBe(false);
+  // Wiring only — the action grammar itself is covered by the action schema suites.
+  test("rejects an invalid action in both `action` and `actions`", () => {
+    expect(
+      OBFButtonSchema.safeParse({ id: "1", action: "hello" }).success,
+    ).toBe(false);
+    expect(
+      OBFButtonSchema.safeParse({ id: "1", actions: [":clear", "hello"] })
+        .success,
+    ).toBe(false);
   });
 
   test("accepts valid positioning bounds", () => {
@@ -366,15 +326,6 @@ describe("OBFButtonSchema", () => {
       expect(result.data.load_board?.id).toBe("1");
       expect(result.data.load_board?.path).toBe("boards/home.obf");
     }
-  });
-
-  test("rejects invalid action in actions array", () => {
-    const invalidActionsArray = {
-      id: "1",
-      actions: [":clear", "invalid-action", ":speak"],
-    };
-
-    expect(OBFButtonSchema.safeParse(invalidActionsArray).success).toBe(false);
   });
 
   test("rejects invalid URL in load_board", () => {
@@ -511,30 +462,22 @@ describe("OBFBoardSchema", () => {
     expect(OBFBoardSchema.safeParse(minimalBoard).success).toBe(true);
   });
 
-  test("requires format field", () => {
-    const missingFormat = {
-      id: "1",
-      buttons: [],
-      grid: { rows: 1, columns: 1, order: [[]] },
-    };
-
-    expect(OBFBoardSchema.safeParse(missingFormat).success).toBe(false);
-  });
-
-  test("requires buttons field", () => {
-    const missingButtons = {
-      format: "open-board-0.1",
-      id: "1",
-      grid: { rows: 1, columns: 1, order: [[]] },
-    };
-
-    expect(OBFBoardSchema.safeParse(missingButtons).success).toBe(false);
-  });
-
-  test("requires grid field", () => {
-    const missingGrid = { format: "open-board-0.1", id: "1", buttons: [] };
-
-    expect(OBFBoardSchema.safeParse(missingGrid).success).toBe(false);
+  test.each([
+    [
+      "format",
+      { id: "1", buttons: [], grid: { rows: 1, columns: 1, order: [[]] } },
+    ],
+    [
+      "buttons",
+      {
+        format: "open-board-0.1",
+        id: "1",
+        grid: { rows: 1, columns: 1, order: [[]] },
+      },
+    ],
+    ["grid", { format: "open-board-0.1", id: "1", buttons: [] }],
+  ])("requires the %s field", (_field, board) => {
+    expect(OBFBoardSchema.safeParse(board).success).toBe(false);
   });
 
   test("rejects invalid format version pattern", () => {
@@ -560,38 +503,32 @@ describe("OBFManifestSchema", () => {
     expect(OBFManifestSchema.safeParse(validManifest).success).toBe(true);
   });
 
-  test("rejects missing format field", () => {
-    const missingFormat = {
-      root: "boards/main.obf",
-      paths: { boards: { main: "boards/main.obf" }, images: {} },
-    };
-
-    expect(OBFManifestSchema.safeParse(missingFormat).success).toBe(false);
-  });
-
-  test("rejects missing root field", () => {
-    const missingRoot = {
-      format: "open-board-0.1",
-      paths: { boards: { main: "boards/main.obf" }, images: {} },
-    };
-
-    expect(OBFManifestSchema.safeParse(missingRoot).success).toBe(false);
-  });
-
-  test("requires paths field", () => {
-    const missingPaths = { format: "open-board-0.1", root: "boards/main.obf" };
-
-    expect(OBFManifestSchema.safeParse(missingPaths).success).toBe(false);
-  });
-
-  test("requires boards in paths", () => {
-    const missingBoards = {
-      format: "open-board-0.1",
-      root: "boards/main.obf",
-      paths: { images: {} },
-    };
-
-    expect(OBFManifestSchema.safeParse(missingBoards).success).toBe(false);
+  test.each([
+    [
+      "format",
+      {
+        root: "boards/main.obf",
+        paths: { boards: { main: "boards/main.obf" }, images: {} },
+      },
+    ],
+    [
+      "root",
+      {
+        format: "open-board-0.1",
+        paths: { boards: { main: "boards/main.obf" }, images: {} },
+      },
+    ],
+    ["paths", { format: "open-board-0.1", root: "boards/main.obf" }],
+    [
+      "paths.boards",
+      {
+        format: "open-board-0.1",
+        root: "boards/main.obf",
+        paths: { images: {} },
+      },
+    ],
+  ])("requires the %s field", (_field, manifest) => {
+    expect(OBFManifestSchema.safeParse(manifest).success).toBe(false);
   });
 
   test("rejects root not listed in paths.boards", () => {

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -109,18 +109,15 @@ describe("unzip limits", () => {
   const filesOf = (...sizes: number[]) =>
     new Map(sizes.map((size, i) => [`file-${i}.bin`, new Uint8Array(size)]));
 
-  test("no options, empty options, empty limits, and undefined options behave identically", async () => {
+  // `{ limits: {} }` installs the filter with no caps; the others skip it entirely.
+  test("no options, empty options, and empty limits behave identically", async () => {
     const zipped = await zip(filesOf(10, 20));
     const buffer = bytesToArrayBuffer(zipped);
 
     const bare = await unzip(buffer);
-    const emptyOptions = await unzip(buffer, {});
-    const emptyLimits = await unzip(buffer, { limits: {} });
-    const explicit = await unzip(buffer, undefined);
 
-    expect(emptyOptions).toEqual(bare);
-    expect(emptyLimits).toEqual(bare);
-    expect(explicit).toEqual(bare);
+    expect(await unzip(buffer, {})).toEqual(bare);
+    expect(await unzip(buffer, { limits: {} })).toEqual(bare);
   });
 
   test("rejects when an entry's declared size exceeds maxEntrySize", async () => {


### PR DESCRIPTION
Removes duplicated coverage and assertions that pinned behavior the package explicitly documents as unstable. No source change — coverage is unchanged at 99.53% statements / 99.1% branches / 100% functions, and 164 tests pass.

Net −71 lines across four test files.

### What changed

- **schema** — Collapsed four near-identical `OBFMediaSchema` accept tests into one `test.each` over the reference styles (each only verified that an optional string field on a `looseObject` accepts a string). Merged the two `OBFImageSchema` accept tests. Reduced the two button action-rejection tests to a single wiring test, since the action grammar is already covered by the action-schema suites. Converted the board and manifest required-field tests to `test.each`.
- **errors** — `archive-too-large` message tests now assert the message *contains* the relevant numbers and path instead of pinning exact wording. The README and `errors.ts` both document messages as outside the stable contract, so the previous assertions broke on any wording tweak; the `info` payloads stay pinned exactly in `zip.test.ts`, and all three formatter branches remain covered. Also corrected the `summarize()` comment, which claimed adding a variant to `OBFErrorInfo` without handling it "would be a compile error" — the `default` arm absorbs new variants, and the real exhaustiveness guard is the `never` check in `formatOBFError`.
- **obz** — Dropped the `parseManifest` root-not-listed test (covered by the schema suite plus the error-contract test in `errors.test.ts`). Merged the two `loadOBZ` tests into one asserting both things the one-line wrapper can actually get wrong: the `File` read and forwarding `options`.
- **zip** — Dropped the `unzip(buffer)` vs `unzip(buffer, undefined)` comparison, which is the same call in JavaScript. Kept the `{}` and `{ limits: {} }` arms, which hit distinct branches.

### Deliberately kept

The real-world `lots-of-stuff` fixture suites, exact-boundary limit checks, the async-inflate and corrupt-entry race tests in `zip.test.ts`, `ext_` preservation, and the offset typed-array view tests. Each pins behavior that genuinely breaks in libraries like this, and several back specific README claims.

### Note on the changeset

Intentionally empty. CI requires a changeset for any `src/` change, but this touches only test files, so no release should be cut — `changeset status` confirms no package is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)