### PR TITLE
Optimize README and package metadata for npm discovery

### DIFF
--- a/.changeset/proud-panthers-compare.md
+++ b/.changeset/proud-panthers-compare.md
@@ -1,0 +1,5 @@
+---
+"@shayc/open-board-format": patch
+---
+
+Improve npm presentation: README leads with what the package does, states the measured bundle size (~11 kB min+gzip including fflate), and surfaces AAC Board AI as a production user; package description and keywords expanded for npm search.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/shayc/open-board-format/actions/workflows/ci.yml/badge.svg)](https://github.com/shayc/open-board-format/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/npm/l/@shayc/open-board-format.svg)](LICENSE)
 
-A TypeScript toolkit for [Open Board Format](https://www.openboardformat.org/) — the open standard for Augmentative and Alternative Communication (AAC) boards. OBF (`.obf`) is a JSON file describing a single communication board: buttons, images, sounds, grid layout, metadata. OBZ (`.obz`) is a ZIP archive bundling one or more boards with their media and a `manifest.json`. This package parses, validates, and creates both.
+A TypeScript toolkit that parses, validates, and creates [Open Board Format](https://www.openboardformat.org/) files — the open standard for Augmentative and Alternative Communication (AAC) boards. OBF (`.obf`) is a JSON file describing a single communication board: buttons, images, sounds, grid layout, metadata. OBZ (`.obz`) is a ZIP archive bundling one or more boards with their media and a `manifest.json`. This package handles both, and powers [AAC Board AI](https://aacboard.app), an offline-first AAC web app.
 
 ```
 my-board.obz
@@ -21,7 +21,7 @@ my-board.obz
 - **Browser and Node.js 22+** — pure ESM, works against `File`, `Blob`, `ArrayBuffer`, or any typed-array view (e.g. Node's `Buffer`).
 - **One entry point for either format** — `loadBoard` sniffs the bytes and tells you whether it found an `.obf` board or an `.obz` package.
 - **Spec-faithful round trips** — unknown fields are preserved rather than stripped, so vendor extensions allowed by the OBF spec survive `parseOBF` → `stringifyOBF`.
-- **Small footprint** — one runtime dependency ([fflate](https://github.com/101arrowz/fflate)) plus Zod as a peer, tree-shakeable, no side effects.
+- **Small footprint** — ~11 kB min+gzip including the single runtime dependency ([fflate](https://github.com/101arrowz/fflate)); Zod is a peer, and the package is tree-shakeable with no side effects.
 
 **Contents:** [Install](#install) · [Quick start](#quick-start) · [Usage](#usage) · [API](#api) · [Errors](#errors) · [Security](#security) · [Scope](#scope) · [Versioning](#versioning) · [Contributing](#contributing) · [Related](#related) · [License](#license)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shayc/open-board-format",
   "version": "1.3.0",
-  "description": "A TypeScript toolkit for Open Board Format — the open standard for Augmentative and Alternative Communication (AAC) boards.",
+  "description": "Parse, validate, and create Open Board Format (.obf/.obz) files — the open standard for Augmentative and Alternative Communication (AAC) boards. TypeScript, browser and Node.js.",
   "license": "MIT",
   "author": "Shay Cojocaru <shayc@outlook.com>",
   "homepage": "https://github.com/shayc/open-board-format#readme",
@@ -16,10 +16,14 @@
     "aac",
     "aac-board",
     "assistive-technology",
+    "augmentative-alternative-communication",
     "communication-board",
     "obf",
     "obz",
-    "open-board-format"
+    "open-board-format",
+    "parser",
+    "validator",
+    "zod"
   ],
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
Optimizes the top of the README for the npm comparison window and package.json for npm search:

- **README intro** now leads with what the package does ("parses, validates, and creates…") and ends with production social proof ([AAC Board AI](https://aacboard.app)).
- **Footprint bullet** states the measured size: ~11 kB min+gzip including fflate (3.5 kB for the package alone), measured with esbuild against the built output (zod external).
- **package.json description** rewritten around the verbs people search for, with the `.obf`/`.obz` extensions included.
- **Keywords** broadened with `augmentative-alternative-communication`, `parser`, `validator`, `zod`.

Includes a patch changeset — the description/keyword changes only reach npm on publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)