### PR TITLE
Harden CI workflow checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
   push:
     branches: [main]
+permissions:
+  contents: read
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -13,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["22", "24"]
+        node: ["22", "24", "26"]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -36,12 +38,24 @@ jobs:
         with:
           fetch-depth: 0
       - name: Require a changeset when src/ changes
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin "${{ github.base_ref }}" --quiet
-          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- src/ | grep -q .; then
-            if ! git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- .changeset \
-                | grep -v -E '(config\.json|README\.md)' | grep -q .; then
-              echo "::error::This PR changes src/ but adds no changeset. Run 'npm run changeset' to record a patch/minor/major bump."
-              exit 1
-            fi
+          set -euo pipefail
+          range="origin/$BASE_REF...HEAD"
+
+          src_changes="$(git diff --name-only "$range" -- src/)"
+          if [[ -z "$src_changes" ]]; then
+            exit 0
+          fi
+
+          changeset_additions="$(
+            git diff --name-only --diff-filter=A "$range" -- \
+              ':(glob).changeset/*.md' \
+              ':(exclude).changeset/README.md'
+          )"
+
+          if [[ -z "$changeset_additions" ]]; then
+            echo "::error::This PR changes src/ but adds no changeset. Run 'npm run changeset' to record a patch/minor/major bump."
+            exit 1
           fi


### PR DESCRIPTION
## Summary

- restrict the CI workflow token to read-only repository contents
- test the package on Node.js 26 in addition to Node.js 22 and 24
- remove the redundant base-branch fetch
- make changeset detection fail safely and require a newly added changeset Markdown file

## Why

The package supports Node.js 22 and newer, so CI should cover the current Node.js release. The changeset check also relied on pipelines that could behave unexpectedly under `pipefail`, and its message claimed to require an added changeset while accepting modified or deleted files.

## Impact

There are no runtime code changes. Pull requests that modify `src/` must now add a new `.changeset/*.md` file.

## Validation

- `npm run format:check`
- `git diff --check`
