### PR TITLE
Harden CI checkout and align Changesets schema

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],

--- a/.changeset/tidy-ci-flow.md
+++ b/.changeset/tidy-ci-flow.md
@@ -1,0 +1,5 @@
+---
+"@shayc/open-board-format": patch
+---
+
+Validate the Changesets v3 release flow after hardening CI checkout credentials.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         node: ["22", "24", "26"]
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
@@ -37,6 +39,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Require a changeset when src/ changes
         env:
           BASE_REF: ${{ github.base_ref }}


### PR DESCRIPTION
## Summary

- disable persisted Git credentials in both CI checkout steps
- update the Changesets configuration schema reference to v4
- add a patch changeset to exercise the Changesets v3 release flow

## Why

The CI jobs do not need authenticated Git operations after checkout, so credentials should not remain available to later steps. The schema reference should also match the version used by Changesets v3.

## Impact

There are no runtime code changes. The included changeset plans a patch release from `1.3.1` to `1.3.2`, allowing the version and publishing workflow to be tested end to end.

## Validation

- `npm run format:check`
- `npm run changeset -- status --verbose`
- `git diff --check`
