### PR TITLE
Improve README documentation

### DIFF
--- a/.changeset/clear-boards-guide.md
+++ b/.changeset/clear-boards-guide.md
@@ -1,0 +1,5 @@
+---
+"@shayc/open-board-format": patch
+---
+
+Rewrite the README as a decision-first package guide with accurate API, validation, error, and security documentation.

--- a/README.md
+++ b/README.md
@@ -1,29 +1,20 @@
 # `@shayc/open-board-format`
 
 [![npm version](https://img.shields.io/npm/v/@shayc/open-board-format)](https://www.npmjs.com/package/@shayc/open-board-format)
-[![CI](https://github.com/shayc/open-board-format/actions/workflows/ci.yml/badge.svg)](https://github.com/shayc/open-board-format/actions/workflows/ci.yml)
+[![CI status](https://github.com/shayc/open-board-format/actions/workflows/ci.yml/badge.svg)](https://github.com/shayc/open-board-format/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/npm/l/@shayc/open-board-format.svg)](LICENSE)
 
-A TypeScript toolkit that parses, validates, and creates [Open Board Format](https://www.openboardformat.org/) files — the open standard for Augmentative and Alternative Communication (AAC) boards. OBF (`.obf`) is a JSON file describing a single communication board: buttons, images, sounds, grid layout, metadata. OBZ (`.obz`) is a ZIP archive bundling one or more boards with their media and a `manifest.json`. This package handles both, and powers [AAC Board AI](https://aacboard.app), an offline-first AAC web app.
+Parse, structurally validate, and create [Open Board Format](https://www.openboardformat.org/) (`.obf` / `.obz`) files in TypeScript or JavaScript. Use it to add augmentative and alternative communication (AAC) board import and export to a browser or Node.js app without implementing format detection, schemas, manifests, or ZIP handling yourself.
 
-```
-my-board.obz
-├── manifest.json        ← table of contents: root board + id-to-path maps
-├── boards/
-│   └── home.obf         ← one JSON board per file
-├── images/
-│   └── dog.png
-└── sounds/
-    └── hello.mp3
-```
+- One function accepts either format: `loadBoard(input)`.
+- Every public OBF model has an exported [Zod](https://zod.dev/) schema and inferred TypeScript type.
+- Unknown fields are preserved, so `ext_*` vendor data survives parsing and serialization.
+- `createOBZ` generates the manifest, validates boards, and checks declared media resources.
+- Pure ESM for Node.js 22+ and modern browsers; declares `sideEffects: false`.
 
-- **Typed end to end** — every type is inferred from a [Zod](https://zod.dev/) schema, and every schema is exported for `safeParse` or composing into your own contracts.
-- **Browser and Node.js 22+** — pure ESM, works against `File`, `Blob`, `ArrayBuffer`, or any typed-array view (e.g. Node's `Buffer`).
-- **One entry point for either format** — `loadBoard` sniffs the bytes and tells you whether it found an `.obf` board or an `.obz` package.
-- **Spec-faithful round trips** — unknown fields are preserved rather than stripped, so vendor extensions allowed by the OBF spec survive `parseOBF` → `stringifyOBF`.
-- **Small footprint** — ~11 kB min+gzip including the single runtime dependency ([fflate](https://github.com/101arrowz/fflate)); Zod is a peer, and the package is tree-shakeable with no side effects.
+This is a data-format library. It does not render boards, play media, or fetch remote resources. It powers [AAC Board AI](https://aacboard.app).
 
-**Contents:** [Install](#install) · [Quick start](#quick-start) · [Usage](#usage) · [API](#api) · [Errors](#errors) · [Security](#security) · [Scope](#scope) · [Versioning](#versioning) · [Contributing](#contributing) · [Related](#related) · [License](#license)
+**Jump to:** [Choose an API](#choose-an-api) · [Usage](#usage) · [Validation behavior](#validation-behavior) · [API reference](#api-reference) · [Errors](#errors) · [Security](#security)
 
 ## Install
 
@@ -31,75 +22,99 @@ my-board.obz
 npm install @shayc/open-board-format zod
 ```
 
-`zod` 4 is a peer dependency — npm 7+ installs it automatically, but pnpm and Yarn users should add it explicitly (as shown above).
+`zod` `^4.4.3` is a required peer dependency. Installing it explicitly keeps setup consistent across package managers and lets this package share your application's Zod instance.
 
-ESM only — CommonJS (`require`) is not supported.
+The package is ESM only. CommonJS `require()` is not supported.
 
 ## Quick start
 
 ```ts
 import { loadBoard } from "@shayc/open-board-format";
+import type { BinaryInput, OBFBoard } from "@shayc/open-board-format";
 
-// `file` came from drag-and-drop or <input type="file"> — could be .obf or .obz
-const loaded = await loadBoard(file);
+export async function loadRootBoard(input: BinaryInput): Promise<OBFBoard> {
+  const loaded = await loadBoard(input);
 
-if (loaded.format === "obf") {
-  console.log(loaded.board.buttons.length);
-} else {
-  console.log(loaded.archive.rootBoard.buttons.length);
+  return loaded.format === "obf" ? loaded.board : loaded.archive.rootBoard;
 }
 ```
 
-`loadBoard` accepts a `File`, `Blob`, `ArrayBuffer`, or any typed-array view (e.g. a Node `Buffer`), and throws on invalid input (see [Errors](#errors)). Already holding a JSON string? `parseOBF(json)` returns a validated `OBFBoard` directly.
-
-In Node.js, read the file first — there's no `File` API outside the browser, but `readFile`'s `Buffer` works directly:
+`BinaryInput` is `File | Blob | ArrayBuffer | ArrayBufferView`, so browser files, fetched blobs, typed arrays, and Node.js `Buffer` values work directly. Detection uses the bytes, not the filename.
 
 ```ts
 import { readFile } from "node:fs/promises";
-import { loadBoard } from "@shayc/open-board-format";
 
-const loaded = await loadBoard(await readFile("my-board.obz"));
+const board = await loadRootBoard(await readFile("my-board.obz"));
+console.log(board.name, board.buttons.length);
 ```
 
+For untrusted OBZ input, choose extraction limits and read their [security limitations](#security) before treating them as a resource boundary.
+
+## Choose an API
+
+| You have                                | Use                                          | Result                 |
+| --------------------------------------- | -------------------------------------------- | ---------------------- |
+| OBF JSON text                           | `parseOBF(json)`                             | Validated `OBFBoard`   |
+| An already-parsed unknown value         | `validateOBF(value)`                         | Validated `OBFBoard`   |
+| A known OBF `File`                      | `loadOBF(file)`                              | `Promise<OBFBoard>`    |
+| A known OBZ `File`                      | `loadOBZ(file, options?)`                    | `Promise<ParsedOBZ>`   |
+| OBZ binary data                         | `extractOBZ(input, options?)`                | `Promise<ParsedOBZ>`   |
+| OBF or OBZ binary data                  | `loadBoard(input, options?)`                 | `Promise<LoadedBoard>` |
+| Boards and optional media bytes         | `createOBZ(boards, rootBoardId, resources?)` | `Promise<Blob>`        |
+| Custom validation or schema composition | Exported `*Schema` values                    | Zod parse result       |
+
+Here, `File` means the Web Platform `File` object, not a filesystem path. For Node.js `Buffer` values or other binary input, use `loadBoard` for either format or `extractOBZ` for known OBZ input.
+
+Use `loadBoard` unless you already know the format or already hold parsed JSON.
+
+## Formats at a glance
+
+- OBF (`.obf`) is one JSON communication board.
+- OBZ (`.obz`) is a ZIP package containing one or more boards and optional media.
+
+```text
+my-board.obz
+├── manifest.json
+├── boards/
+│   └── home.obf
+├── images/
+│   └── dog.png
+└── sounds/
+    └── hello.mp3
+```
+
+This library requires `manifest.json` at the archive root for every OBZ package, including packages containing one board.
+
 ## Usage
-
-### Which function do I need?
-
-- **You have a single board (OBF).** Use `parseOBF` for a JSON string, `validateOBF` for an already-parsed object, `loadOBF` for a browser `File`. `stringifyOBF` serializes back out.
-- **You have a package of boards plus media (OBZ).** Use `extractOBZ` for a `File`, `Blob`, `ArrayBuffer`, or typed-array view (`loadOBZ` is the same thing, `File`-only); `createOBZ` to build a new one.
-- **You don't know which you have.** Use `loadBoard` — it sniffs the bytes and returns a `{ format, ... }` union so you don't have to inspect the file extension yourself.
 
 ### Read an OBZ package
 
 ```ts
-import { loadOBZ, extractOBZ } from "@shayc/open-board-format";
+import { extractOBZ } from "@shayc/open-board-format";
+import type { BinaryInput, ParsedOBZ } from "@shayc/open-board-format";
 
-// From a File (e.g. drag-and-drop)
-const { rootBoard, boards, resources } = await loadOBZ(file);
-
-// Or from anything else — ArrayBuffer, Blob, Node Buffer, etc.
-const parsed = await extractOBZ(buffer);
-
-// Untrusted input? Cap declared uncompressed sizes (see Security)
-const guarded = await extractOBZ(buffer, {
-  limits: { maxTotalOriginalSize: 500e6 },
-});
+export function extractPackage(input: BinaryInput): Promise<ParsedOBZ> {
+  return extractOBZ(input, {
+    limits: {
+      // Examples only—choose limits appropriate for your application.
+      maxEntrySize: 100 * 1024 ** 2, // 100 MiB
+      maxTotalOriginalSize: 500 * 1024 ** 2, // 500 MiB
+      maxEntries: 10_000,
+    },
+  });
+}
 ```
 
-`rootBoard` is the package's home board — the one `manifest.root` points at, already resolved. `boards` is keyed by board ID and `resources` by archive path; the `manifest` is also returned if you need the raw table of contents.
-
-Resources are raw bytes. To display an image in the browser:
-
-```ts
-const bytes = resources.get("images/hello.png")!;
-const url = URL.createObjectURL(new Blob([bytes]));
-```
+- `rootBoard` is the board referenced by `manifest.root`.
+- `boards` is a `Map` keyed by board ID.
+- `resources` contains the raw bytes of every file entry, including `manifest.json`, board files, media, and unrelated extra files. Directory entries are omitted.
 
 ### Create an OBZ package
 
-Buttons reference media by ID (`image_id`, `sound_id`); the board's `images`/`sounds` entries carry the archive `path`; the resources map supplies the bytes for each path. Every `path` a board declares must have a matching resource entry, or `createOBZ` throws.
+Buttons can reference media by ID. An entry in `images` or `sounds` can declare an archive `path`, and the `resources` map supplies the bytes for that path. `createOBZ` throws when a declared image or sound path has no matching resource.
 
 ```ts
+import { readFile, writeFile } from "node:fs/promises";
 import { createOBZ } from "@shayc/open-board-format";
 import type { OBFBoard } from "@shayc/open-board-format";
 
@@ -111,198 +126,224 @@ const board: OBFBoard = {
   images: [{ id: "img-1", path: "images/hello.png" }],
 };
 
-const pngBytes = new Uint8Array(/* ... */);
+const pngBytes = await readFile("hello.png");
 const resources = new Map([["images/hello.png", pngBytes]]);
 
 const blob = await createOBZ([board], "board-1", resources);
+await writeFile("my-board.obz", new Uint8Array(await blob.arrayBuffer()));
 ```
 
-The `manifest.json` is generated for you — boards are written to `boards/<id>.obf` (the id is percent-encoded, so it's always a safe filename), and `rootBoardId` (the second argument) selects the home board.
+The manifest is generated automatically. Boards are written to `boards/<encoded-id>.obf`, and `rootBoardId` selects the entry board. `createOBZ` checks duplicate board IDs, unknown roots, generated-path collisions, conflicting media paths, and missing declared media resources. It does not resolve `load_board` links or button-to-media references.
 
-### Validate with Zod directly
+### Use the schemas directly
 
 ```ts
 import { OBFBoardSchema } from "@shayc/open-board-format";
 
-const result = OBFBoardSchema.safeParse(data);
+export function inspectBoard(value: unknown): void {
+  const result = OBFBoardSchema.safeParse(value);
 
-if (result.success) {
-  console.log(result.data.buttons);
-} else {
-  console.error(result.error.issues);
-}
-```
-
-## API
-
-One naming convention covers the whole surface: `parse*` takes a JSON string, `validate*` takes an already-parsed object, `load*` takes a browser `File`, `stringify*` returns a JSON string — and `extractOBZ`/`loadBoard` also accept a `Blob`, `ArrayBuffer`, or typed-array view (e.g. a Node `Buffer`), for use outside the browser.
-
-### OBF (single board)
-
-| Function              | Returns             | Description                                                  |
-| --------------------- | ------------------- | ------------------------------------------------------------ |
-| `parseOBF(json)`      | `OBFBoard`          | Parse a JSON string into a validated `OBFBoard`              |
-| `validateOBF(data)`   | `OBFBoard`          | Validate an unknown object as `OBFBoard` (throws on failure) |
-| `stringifyOBF(board)` | `string`            | Serialize an `OBFBoard` to a JSON string                     |
-| `loadOBF(file)`       | `Promise<OBFBoard>` | Load an `OBFBoard` from a browser `File`                     |
-
-### OBZ (board package)
-
-| Function                                     | Returns              | Description                                                                                                   |
-| -------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `loadOBZ(file, options?)`                    | `Promise<ParsedOBZ>` | Load an OBZ package from a browser `File`                                                                     |
-| `extractOBZ(archive, options?)`              | `Promise<ParsedOBZ>` | Extract boards, manifest, root board, and resources from a `File`, `Blob`, `ArrayBuffer`, or typed-array view |
-| `createOBZ(boards, rootBoardId, resources?)` | `Promise<Blob>`      | Create an OBZ package as a `Blob`                                                                             |
-| `parseManifest(json)`                        | `OBFManifest`        | Parse a `manifest.json` string into a validated `OBFManifest`                                                 |
-
-### Format detection
-
-| Function                     | Returns                | Description                                                                                                            |
-| ---------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `loadBoard(input, options?)` | `Promise<LoadedBoard>` | Detect OBF vs OBZ from a `File`, `Blob`, `ArrayBuffer`, or typed-array view and load it; returns a `LoadedBoard` union |
-
-### Utilities
-
-| Function                   | Returns                            | Description                                              |
-| -------------------------- | ---------------------------------- | -------------------------------------------------------- |
-| `isZip(archive)`           | `boolean`                          | Check if an `ArrayBuffer` starts with a ZIP magic number |
-| `zip(entries)`             | `Promise<Uint8Array>`              | Create a ZIP from a map of paths to buffers              |
-| `unzip(archive, options?)` | `Promise<Map<string, Uint8Array>>` | Extract a ZIP into a map of paths to `Uint8Array`        |
-
-### Types
-
-| Type                  | Description                                                                                                    |
-| --------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `OBFBoard`            | A single communication board                                                                                   |
-| `OBFGrid`             | Grid layout (rows, columns, order)                                                                             |
-| `OBFButton`           | A button on the board                                                                                          |
-| `OBFButtonAction`     | Button action (spelling or specialty)                                                                          |
-| `OBFSpellingAction`   | Spelling action (e.g., `+s`)                                                                                   |
-| `OBFSpecialtyAction`  | Specialty action (e.g., `:clear`)                                                                              |
-| `OBFLoadBoard`        | Reference to load another board                                                                                |
-| `OBFMedia`            | Common media properties (base for `OBFImage` and `OBFSound`)                                                   |
-| `OBFImage`            | An image resource (extends `OBFMedia`)                                                                         |
-| `OBFSound`            | A sound resource (alias of `OBFMedia`)                                                                         |
-| `OBFSymbolInfo`       | Symbol set reference                                                                                           |
-| `OBFManifest`         | OBZ package manifest                                                                                           |
-| `ParsedOBZ`           | Return type of `extractOBZ` / `loadOBZ` — `{ manifest, boards, rootBoard, resources }`                         |
-| `LoadedBoard`         | Return type of `loadBoard` — `{ format: "obz", archive } \| { format: "obf", board }`                          |
-| `BinaryInput`         | Input type of `loadBoard` / `extractOBZ` — `File \| Blob \| ArrayBuffer \| ArrayBufferView`                    |
-| `UnzipLimits`         | Optional extraction caps — `{ maxEntrySize?, maxTotalOriginalSize?, maxEntries? }` (see [Security](#security)) |
-| `UnzipOptions`        | Options for `unzip` / `extractOBZ` / `loadOBZ` / `loadBoard` — `{ limits?: UnzipLimits }`                      |
-| `OBFID`               | Unique identifier (string, coerced from number)                                                                |
-| `OBFFormatVersion`    | Format version string (e.g., `open-board-0.1`)                                                                 |
-| `OBFLicense`          | Licensing information                                                                                          |
-| `OBFLocaleCode`       | BCP 47 locale code                                                                                             |
-| `OBFLocalizedStrings` | Key-value string translations                                                                                  |
-| `OBFStrings`          | Multi-locale string translations                                                                               |
-
-### Schemas
-
-Every type above except `ParsedOBZ`, `LoadedBoard`, `BinaryInput`, `UnzipLimits`, and `UnzipOptions` is exported alongside a matching Zod schema with a `Schema` suffix — `OBFBoard` → `OBFBoardSchema`, `OBFManifest` → `OBFManifestSchema`, and so on. Import any of them to validate with `safeParse`/`parse` or to compose into your own schemas:
-
-```ts
-import { OBFButtonSchema, OBFManifestSchema } from "@shayc/open-board-format";
-```
-
-## Errors
-
-Every failure throws an `OBFError`. Branch on `error.info.code` — a discriminated union where each `code` carries exactly the fields relevant to that failure. Don't match on `error.message`; the message is human-readable and may change between releases.
-
-```ts
-import { loadBoard, OBFError } from "@shayc/open-board-format";
-
-try {
-  await loadBoard(file);
-} catch (error) {
-  if (!(error instanceof OBFError)) throw error;
-
-  switch (error.info.code) {
-    case "missing-resource":
-      // `kind`, `mediaId`, and `path` are all typed and present here
-      console.warn(`Missing ${error.info.kind} at ${error.info.path}`);
-      break;
-    case "invalid-board":
-      // `issues` is the Zod issue list — which field failed and why
-      console.error(error.info.issues);
-      break;
-    default:
-      console.error(error.message);
+  if (result.success) {
+    console.log(result.data.buttons);
+  } else {
+    console.error(result.error.issues);
   }
 }
 ```
 
-The `code` values, grouped by what they describe:
+Use Zod's `.extend()`, `.pick()`, or other composition APIs to build application-specific contracts from the exported schemas.
 
-| Group       | `info.code`         | Key fields (on `info`)                        |
-| ----------- | ------------------- | --------------------------------------------- |
-| Decoding    | `not-json`          | `source`                                      |
-|             | `not-zip`           | —                                             |
-|             | `unreadable-zip`    | —                                             |
-|             | `archive-too-large` | `limit`, `path`, and the tripped cap's fields |
-| Validation  | `invalid-board`     | `issues`, `boardId?`                          |
-|             | `invalid-manifest`  | `issues`                                      |
-| Read (OBZ)  | `missing-manifest`  | —                                             |
-|             | `missing-board`     | `boardId`, `path`                             |
-|             | `board-id-mismatch` | `path`, `declaredId`, `actualId`              |
-| Write (OBZ) | `unknown-root`      | `rootBoardId`                                 |
-|             | `duplicate-board`   | `boardId`                                     |
-|             | `missing-resource`  | `kind`, `mediaId`, `path`                     |
-|             | `conflicting-paths` | `kind`, `mediaId`, `paths`                    |
-|             | `path-collision`    | `path`                                        |
-|             | `zip-failed`        | —                                             |
-| Internal    | `internal`          | `detail`                                      |
+## Validation behavior
 
-`OBFErrorInfo` and `OBFErrorCode` are exported for exhaustive handling.
+Validation returns a parsed copy and may normalize known fields:
 
-- The underlying error, when there is one, is always on the standard `error.cause` — never duplicated on `info`.
-- Validation failures (`invalid-board`, `invalid-manifest`) put the `ZodError` on `error.cause`, so `z.treeifyError(error.cause)` gives nested, UI-friendly output, while `info.issues` (Zod's issue type, re-exported as `OBFIssue`) gives you the flat list directly.
-- For `not-json` / `*-zip` failures, `error.cause` is the underlying parser or fflate error.
-- An `internal` code signals a bug in this library that callers can't recover from — please report it.
+- Numeric IDs are converted to strings.
+- Empty optional IDs, URLs, and email addresses become `undefined`.
+- Unknown properties are preserved at every loose-object level, whether or not they use the `ext_` prefix.
+- URL and email fields are syntax-checked.
+- Grid dimensions must be integers from 1 through 100, and `order` must exactly match `rows` and `columns`.
+- A positioned button must provide all four of `top`, `left`, `width`, and `height`, each from 0 through 1.
+- Format versions must match `open-board-*`; validation does not restrict them to `open-board-0.1`.
+- An OBZ manifest root must appear in `paths.boards`.
 
-**Re-zipping an extracted `.obz` by hand?** Zip the folder's _contents_, not the folder itself. If `manifest.json` ends up nested inside a top-level folder in the archive, extraction fails with `missing-manifest` even though the file is right there.
+Validation is structural, not a complete OBF conformance or graph-integrity check. It does not enforce:
+
+- Unique button, image, or sound IDs.
+- That `grid.order`, `image_id`, `sound_id`, or `load_board` references resolve.
+- That every button on a board uses the same positioning mode.
+- BCP 47 locale syntax, color syntax, MIME correctness, or safe HTML.
+- During extraction, that manifest-declared media paths exist or agree with board media entries.
+
+Add application-specific checks after parsing when those guarantees matter.
+
+## API reference
+
+### OBF
+
+| Function              | Returns             | Behavior                                                    |
+| --------------------- | ------------------- | ----------------------------------------------------------- |
+| `parseOBF(json)`      | `OBFBoard`          | Parse JSON and validate a board; strips a leading UTF-8 BOM |
+| `validateOBF(value)`  | `OBFBoard`          | Validate and normalize an unknown value                     |
+| `stringifyOBF(board)` | `string`            | Two-space JSON serialization; does not revalidate           |
+| `loadOBF(file)`       | `Promise<OBFBoard>` | Read a `File`, then parse and validate it                   |
+
+### OBZ
+
+| Function                                     | Returns              | Behavior                                                            |
+| -------------------------------------------- | -------------------- | ------------------------------------------------------------------- |
+| `loadOBZ(file, options?)`                    | `Promise<ParsedOBZ>` | `File` convenience wrapper around `extractOBZ`                      |
+| `extractOBZ(input, options?)`                | `Promise<ParsedOBZ>` | Extract and validate the manifest and every manifest-declared board |
+| `createOBZ(boards, rootBoardId, resources?)` | `Promise<Blob>`      | Validate and package boards/resources with a generated manifest     |
+| `parseManifest(json)`                        | `OBFManifest`        | Parse and validate manifest JSON                                    |
+
+`ParsedOBZ` is `{ manifest, boards, rootBoard, resources }`.
+
+### Format detection
+
+| Function                     | Returns                | Behavior                                                                                 |
+| ---------------------------- | ---------------------- | ---------------------------------------------------------------------------------------- |
+| `loadBoard(input, options?)` | `Promise<LoadedBoard>` | Sniff OBF vs OBZ, then return `{ format: "obf", board }` or `{ format: "obz", archive }` |
+
+### ZIP utilities
+
+| Function                  | Returns                            | Behavior                                                |
+| ------------------------- | ---------------------------------- | ------------------------------------------------------- |
+| `isZip(buffer)`           | `boolean`                          | Check only for the two-byte `PK` prefix                 |
+| `zip(entries)`            | `Promise<Uint8Array>`              | Compress a map of paths to `Uint8Array` / `ArrayBuffer` |
+| `unzip(buffer, options?)` | `Promise<Map<string, Uint8Array>>` | Extract an `ArrayBuffer`; omit directory-marker entries |
+
+### Exported types and schemas
+
+- **Boards and actions:** `OBFBoard`, `OBFGrid`, `OBFButton`, `OBFButtonAction`, `OBFSpellingAction`, `OBFSpecialtyAction`, `OBFLoadBoard`
+- **Media and metadata:** `OBFMedia`, `OBFImage`, `OBFSound`, `OBFSymbolInfo`, `OBFLicense`, `OBFID`, `OBFFormatVersion`, `OBFLocaleCode`, `OBFLocalizedStrings`, `OBFStrings`, `OBFManifest`
+- **Results and input:** `ParsedOBZ`, `LoadedBoard`, `BinaryInput`
+- **ZIP options:** `UnzipLimits`, `UnzipOptions`
+- **Errors:** `OBFError`, `OBFErrorInfo`, `OBFErrorCode`, `OBFIssue`
+
+Every board/media model type has a matching exported Zod schema with a `Schema` suffix: `OBFBoardSchema`, `OBFButtonSchema`, `OBFManifestSchema`, and so on. `ParsedOBZ`, `LoadedBoard`, binary/ZIP types, and error types do not have matching schemas.
+
+`OBFLocaleCode` is a locale string, typically BCP 47, but its syntax is not validated.
+
+## Errors
+
+Expected parsing, validation, and archive-domain failures from the high-level functions use `OBFError`. Branch on `error.info.code`, not `error.message`.
+
+```ts
+import { loadBoard, OBFError } from "@shayc/open-board-format";
+import type { BinaryInput, LoadedBoard } from "@shayc/open-board-format";
+
+export async function openBoard(input: BinaryInput): Promise<LoadedBoard> {
+  try {
+    return await loadBoard(input);
+  } catch (error) {
+    if (!(error instanceof OBFError)) throw error;
+
+    switch (error.info.code) {
+      case "invalid-board":
+        console.error(error.info.issues);
+        break;
+      case "missing-board":
+        console.error(error.info.boardId, error.info.path);
+        break;
+      default:
+        console.error(error.message);
+    }
+
+    throw error;
+  }
+}
+```
+
+| Area           | `info.code`         | Additional fields                                  |
+| -------------- | ------------------- | -------------------------------------------------- |
+| Decoding       | `not-json`          | `source`                                           |
+| Decoding       | `not-zip`           | —                                                  |
+| Decoding       | `unreadable-zip`    | —                                                  |
+| Limits         | `archive-too-large` | `limit`, `path`, and fields for the exceeded limit |
+| Validation     | `invalid-board`     | `issues`, `boardId?`                               |
+| Validation     | `invalid-manifest`  | `issues`                                           |
+| OBZ extraction | `missing-manifest`  | —                                                  |
+| OBZ extraction | `missing-board`     | `boardId`, `path`                                  |
+| OBZ extraction | `board-id-mismatch` | `path`, `declaredId`, `actualId`                   |
+| OBZ creation   | `unknown-root`      | `rootBoardId`                                      |
+| OBZ creation   | `duplicate-board`   | `boardId`                                          |
+| OBZ creation   | `missing-resource`  | `kind`, `mediaId`, `path`                          |
+| OBZ creation   | `conflicting-paths` | `kind`, `mediaId`, `paths`                         |
+| OBZ creation   | `path-collision`    | `path`                                             |
+| OBZ creation   | `zip-failed`        | —                                                  |
+| Internal       | `internal`          | `detail`                                           |
+
+- Validation failures put the `ZodError` on `error.cause` and its flat issue list on `error.info.issues`.
+- `not-json`, `unreadable-zip`, and `zip-failed` put the underlying parser or fflate error on `error.cause`.
+- `internal` indicates a library invariant failure that should be reported.
+
+Schema `.parse()` calls throw `ZodError` directly; `NaN` limits throw `TypeError`, and native I/O, URI encoding, or JSON serialization errors can propagate.
 
 ## Security
 
-OBZ archives are untrusted input. To guard against zip bombs, pass `limits` (via `UnzipOptions`) to `loadBoard` / `loadOBZ` / `extractOBZ` / `unzip`:
+Treat OBZ archives and their contents as untrusted input.
 
 ```ts
-const parsed = await extractOBZ(buffer, {
-  limits: {
-    maxEntrySize: 100e6, // any single entry, in bytes
-    maxTotalOriginalSize: 500e6, // sum of all entries, in bytes
-    maxEntries: 10_000, // entry count, including directory entries
-  },
-});
+import { extractOBZ } from "@shayc/open-board-format";
+import type { BinaryInput, ParsedOBZ } from "@shayc/open-board-format";
+
+export function extractUntrusted(input: BinaryInput): Promise<ParsedOBZ> {
+  return extractOBZ(input, {
+    limits: {
+      // Examples only—choose limits appropriate for your application.
+      maxEntrySize: 100 * 1024 ** 2, // 100 MiB
+      maxTotalOriginalSize: 500 * 1024 ** 2, // 500 MiB
+      maxEntries: 10_000,
+    },
+  });
+}
 ```
 
-Size limits are checked per entry against the uncompressed size declared in the archive's ZIP metadata, before that entry is inflated; `maxEntries` caps how many entries are processed at all. Entries accepted before a later entry trips a limit have already been inflated, but total allocation stays bounded by the caps. Exceeding a limit aborts extraction and rejects with an `OBFError` whose code is `archive-too-large` (`info` carries `limit`, the entry `path` that tripped it, and `maxBytes`/`declaredBytes` for the size limits or `maxEntries`/`entryCount` for the count). No limits are applied by default. A lying header can't force larger allocations — fflate allocates output buffers at exactly the declared size — so the declared-size caps bound memory use.
+The limits are optional and disabled by default. They are checked against sizes declared in ZIP metadata before inflation, and `maxEntries` caps the number of entries processed.
 
-Entry paths are not sanitized — if you write extracted resources to disk, validate paths yourself first to avoid directory traversal.
+These are not hard memory guarantees for a malicious archive. ZIP metadata can be dishonest, and stored entries can produce more output than their declared uncompressed size. Also enforce an input archive-size limit outside this package; use isolation or a streaming design if your threat model requires a strict memory boundary.
 
-Found a security issue? Open a private advisory at [github.com/shayc/open-board-format/security/advisories/new](https://github.com/shayc/open-board-format/security/advisories/new).
+Additional boundaries:
+
+- Archive entry paths are not sanitized. Validate them before writing entries to disk to prevent directory traversal.
+- `description_html` is not sanitized. Sanitize it before inserting it into the DOM.
+- URLs and `data_url` values are validated syntactically but never fetched.
+
+Found a vulnerability? Email [shayc@outlook.com](mailto:shayc@outlook.com) rather than opening a public issue.
+
+## Runtime and packaging
+
+- Pure ESM; CommonJS is not supported.
+- Node.js `>=22`.
+- Modern browsers with `Blob`, `File`, `TextEncoder`, and `TextDecoder`.
+- Node versions 22, 24, and 26 are covered by CI; browser engines are not currently tested in CI.
+- `fflate` is the only runtime dependency. `zod ^4.4.3` is a peer dependency.
+- The v1.3.2 full-entry build is 9.6 kB gzip using tsdown 0.22.14, with `fflate` bundled and Zod externalized.
+- The package declares `sideEffects: false` and exposes one typed entry point.
 
 ## Scope
 
-What this library deliberately does not do:
+This package handles the OBF/OBZ data and archive layer. It intentionally does not:
 
-- **No network I/O** — media referenced by `url` or `data_url` is not fetched; resolving external media is up to you.
-- **No rendering** — it parses and validates data; drawing boards and playing sounds belong to your app.
-- **No default extraction limits, no path sanitization** — size caps are opt-in via `UnzipOptions`; see [Security](#security) before writing archive contents to disk.
-- **No referential integrity checks** — a `grid.order` id with no matching button, or an `image_id`/`sound_id` with no matching image/sound, is not flagged. Resolving references is up to your rendering layer.
+- Render boards, lay out UI, play sounds, or provide AAC interaction behavior.
+- Fetch media or linked boards from `url` / `data_url` values.
+- Resolve navigation or media references into an application graph.
+- Provide complete semantic conformance validation for the OBF specification.
 
-## Versioning
+## Versioning and support
 
-Semver. The public API — every exported function, type, and Zod schema — is stable; breaking changes ship as major releases. See [CHANGELOG.md](CHANGELOG.md).
+The public API follows semver. Breaking changes to exported functions, types, schemas, or documented behavior ship as major versions. See [CHANGELOG.md](CHANGELOG.md).
+
+For bugs or questions, [open an issue](https://github.com/shayc/open-board-format/issues) with a minimal OBF/OBZ reproduction, package version, runtime, and bundler where applicable. Report vulnerabilities privately by email instead.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup (Node 22+, Vitest, the changeset workflow).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for Node.js requirements, development commands, tests, and the changeset workflow.
 
 ## Related
 
-- [Open Board Format specification](https://www.openboardformat.org/docs) — the official standard and format documentation. A 1:1 mirror is kept at [docs/external/open-board-format.md](docs/external/open-board-format.md) for offline reference.
-- [AAC Board AI](https://github.com/shayc/aac-board-ai) — an offline-first AAC web app built on this package, using on-device browser AI for grammar, tone, and translation ([live app](https://aacboard.app)).
+- [Open Board Format specification](https://www.openboardformat.org/docs) — official format documentation. An offline mirror is included at [docs/external/open-board-format.md](docs/external/open-board-format.md).
+- [AAC Board AI](https://github.com/shayc/aac-board-ai) — an offline-first AAC web app using this package ([live app](https://aacboard.app)).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,11 @@
 [![CI status](https://github.com/shayc/open-board-format/actions/workflows/ci.yml/badge.svg)](https://github.com/shayc/open-board-format/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/npm/l/@shayc/open-board-format.svg)](LICENSE)
 
-Parse, structurally validate, and create [Open Board Format](https://www.openboardformat.org/) (`.obf` / `.obz`) files in TypeScript or JavaScript. Use it to add augmentative and alternative communication (AAC) board import and export to a browser or Node.js app without implementing format detection, schemas, manifests, or ZIP handling yourself.
+Parse, structurally validate, and create [Open Board Format](https://www.openboardformat.org/) boards (`.obf`) and archives (`.obz`) in TypeScript or JavaScript. Use it to add augmentative and alternative communication (AAC) board import and export without implementing schemas, manifests, or ZIP handling.
 
-- One function accepts either format: `loadBoard(input)`.
-- Every public OBF model has an exported [Zod](https://zod.dev/) schema and inferred TypeScript type.
-- Unknown fields are preserved, so `ext_*` vendor data survives parsing and serialization.
-- `createOBZ` generates the manifest, validates boards, and checks declared media resources.
-- Pure ESM for Node.js 22+ and modern browsers; declares `sideEffects: false`.
+`loadBoard` detects either format from its bytes. `createOBZ` validates boards, generates the manifest, and checks declared media. Unknown fields are preserved, and every public OBF model includes an exported [Zod](https://zod.dev/) schema and inferred type.
 
-This is a data-format library. It does not render boards, play media, or fetch remote resources. It powers [AAC Board AI](https://aacboard.app).
+Pure ESM for Node.js 22+ and modern browsers. This package handles data and archives—it does not render boards, play media, fetch remote resources, or resolve navigation and media references. It powers [AAC Board AI](https://github.com/shayc/aac-board-ai) ([live app](https://aacboard.app)).
 
 **Jump to:** [Choose an API](#choose-an-api) · [Usage](#usage) · [Validation behavior](#validation-behavior) · [API reference](#api-reference) · [Errors](#errors) · [Security](#security)
 
@@ -23,8 +19,6 @@ npm install @shayc/open-board-format zod
 ```
 
 `zod` `^4.4.3` is a required peer dependency. Installing it explicitly keeps setup consistent across package managers and lets this package share your application's Zod instance.
-
-The package is ESM only. CommonJS `require()` is not supported.
 
 ## Quick start
 
@@ -41,15 +35,6 @@ export async function loadRootBoard(input: BinaryInput): Promise<OBFBoard> {
 
 `BinaryInput` is `File | Blob | ArrayBuffer | ArrayBufferView`, so browser files, fetched blobs, typed arrays, and Node.js `Buffer` values work directly. Detection uses the bytes, not the filename.
 
-```ts
-import { readFile } from "node:fs/promises";
-
-const board = await loadRootBoard(await readFile("my-board.obz"));
-console.log(board.name, board.buttons.length);
-```
-
-For untrusted OBZ input, choose extraction limits and read their [security limitations](#security) before treating them as a resource boundary.
-
 ## Choose an API
 
 | You have                                | Use                                          | Result                 |
@@ -64,8 +49,6 @@ For untrusted OBZ input, choose extraction limits and read their [security limit
 | Custom validation or schema composition | Exported `*Schema` values                    | Zod parse result       |
 
 Here, `File` means the Web Platform `File` object, not a filesystem path. For Node.js `Buffer` values or other binary input, use `loadBoard` for either format or `extractOBZ` for known OBZ input.
-
-Use `loadBoard` unless you already know the format or already hold parsed JSON.
 
 ## Formats at a glance
 
@@ -94,20 +77,15 @@ import { extractOBZ } from "@shayc/open-board-format";
 import type { BinaryInput, ParsedOBZ } from "@shayc/open-board-format";
 
 export function extractPackage(input: BinaryInput): Promise<ParsedOBZ> {
-  return extractOBZ(input, {
-    limits: {
-      // Examples only—choose limits appropriate for your application.
-      maxEntrySize: 100 * 1024 ** 2, // 100 MiB
-      maxTotalOriginalSize: 500 * 1024 ** 2, // 500 MiB
-      maxEntries: 10_000,
-    },
-  });
+  return extractOBZ(input);
 }
 ```
 
 - `rootBoard` is the board referenced by `manifest.root`.
 - `boards` is a `Map` keyed by board ID.
 - `resources` contains the raw bytes of every file entry, including `manifest.json`, board files, media, and unrelated extra files. Directory entries are omitted.
+
+For untrusted input, configure [extraction limits](#security) appropriate for your application.
 
 ### Create an OBZ package
 
@@ -140,15 +118,8 @@ The manifest is generated automatically. Boards are written to `boards/<encoded-
 ```ts
 import { OBFBoardSchema } from "@shayc/open-board-format";
 
-export function inspectBoard(value: unknown): void {
-  const result = OBFBoardSchema.safeParse(value);
-
-  if (result.success) {
-    console.log(result.data.buttons);
-  } else {
-    console.error(result.error.issues);
-  }
-}
+export const validateBoard = (value: unknown) =>
+  OBFBoardSchema.safeParse(value);
 ```
 
 Use Zod's `.extend()`, `.pick()`, or other composition APIs to build application-specific contracts from the exported schemas.
@@ -230,25 +201,15 @@ Expected parsing, validation, and archive-domain failures from the high-level fu
 
 ```ts
 import { loadBoard, OBFError } from "@shayc/open-board-format";
-import type { BinaryInput, LoadedBoard } from "@shayc/open-board-format";
+import type { BinaryInput } from "@shayc/open-board-format";
 
-export async function openBoard(input: BinaryInput): Promise<LoadedBoard> {
+export async function openBoard(input: BinaryInput) {
   try {
     return await loadBoard(input);
   } catch (error) {
-    if (!(error instanceof OBFError)) throw error;
-
-    switch (error.info.code) {
-      case "invalid-board":
-        console.error(error.info.issues);
-        break;
-      case "missing-board":
-        console.error(error.info.boardId, error.info.path);
-        break;
-      default:
-        console.error(error.message);
+    if (error instanceof OBFError) {
+      console.error(error.info.code, error.info);
     }
-
     throw error;
   }
 }
@@ -321,29 +282,12 @@ Found a vulnerability? Email [shayc@outlook.com](mailto:shayc@outlook.com) rathe
 - The v1.3.2 full-entry build is 9.6 kB gzip using tsdown 0.22.14, with `fflate` bundled and Zod externalized.
 - The package declares `sideEffects: false` and exposes one typed entry point.
 
-## Scope
+## Project
 
-This package handles the OBF/OBZ data and archive layer. It intentionally does not:
-
-- Render boards, lay out UI, play sounds, or provide AAC interaction behavior.
-- Fetch media or linked boards from `url` / `data_url` values.
-- Resolve navigation or media references into an application graph.
-- Provide complete semantic conformance validation for the OBF specification.
-
-## Versioning and support
-
-The public API follows semver. Breaking changes to exported functions, types, schemas, or documented behavior ship as major versions. See [CHANGELOG.md](CHANGELOG.md).
-
-For bugs or questions, [open an issue](https://github.com/shayc/open-board-format/issues) with a minimal OBF/OBZ reproduction, package version, runtime, and bundler where applicable. Report vulnerabilities privately by email instead.
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for Node.js requirements, development commands, tests, and the changeset workflow.
-
-## Related
-
-- [Open Board Format specification](https://www.openboardformat.org/docs) — official format documentation. An offline mirror is included at [docs/external/open-board-format.md](docs/external/open-board-format.md).
-- [AAC Board AI](https://github.com/shayc/aac-board-ai) — an offline-first AAC web app using this package ([live app](https://aacboard.app)).
+- **Versioning:** The public API follows semver; breaking changes to exported functions, types, schemas, or documented behavior ship as major versions. See [CHANGELOG.md](CHANGELOG.md).
+- **Support:** [Open an issue](https://github.com/shayc/open-board-format/issues) with a minimal reproduction, package version, runtime, and bundler where applicable.
+- **Contributing:** See [CONTRIBUTING.md](CONTRIBUTING.md) for development commands, tests, and the changeset workflow.
+- **Specification:** See the [official documentation](https://www.openboardformat.org/docs) or the included [offline mirror](docs/external/open-board-format.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # `@shayc/open-board-format`
 
+[![npm version](https://img.shields.io/npm/v/@shayc/open-board-format)](https://www.npmjs.com/package/@shayc/open-board-format)
+[![CI](https://github.com/shayc/open-board-format/actions/workflows/ci.yml/badge.svg)](https://github.com/shayc/open-board-format/actions/workflows/ci.yml)
+
 Parse, validate, and create [Open Board Format](https://www.openboardformat.org/) (OBF) communication boards (`.obf`) and archives (`.obz`) for augmentative and alternative communication (AAC) applications in TypeScript or JavaScript.
 
 Add AAC board import and export without implementing schemas, manifests, or archive handling yourself.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # `@shayc/open-board-format`
 
-[![npm version](https://img.shields.io/npm/v/@shayc/open-board-format)](https://www.npmjs.com/package/@shayc/open-board-format)
-[![CI status](https://github.com/shayc/open-board-format/actions/workflows/ci.yml/badge.svg)](https://github.com/shayc/open-board-format/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/npm/l/@shayc/open-board-format.svg)](LICENSE)
+Parse, validate, and create [Open Board Format](https://www.openboardformat.org/) (OBF) communication boards (`.obf`) and archives (`.obz`) for augmentative and alternative communication (AAC) applications in TypeScript or JavaScript.
 
-Parse, structurally validate, and create [Open Board Format](https://www.openboardformat.org/) boards (`.obf`) and archives (`.obz`) in TypeScript or JavaScript. Use it to add augmentative and alternative communication (AAC) board import and export without implementing schemas, manifests, or ZIP handling.
+Add AAC board import and export without implementing schemas, manifests, or archive handling yourself.
 
-`loadBoard` detects either format from its bytes. `createOBZ` validates boards, generates the manifest, and checks declared media. Unknown fields are preserved, and every public OBF model includes an exported [Zod](https://zod.dev/) schema and inferred type.
+The package handles format detection, validation, archive creation, and schema access so applications can focus on board experiences instead of file handling.
 
-Pure ESM for Node.js 22+ and modern browsers. This package handles data and archives—it does not render boards, play media, fetch remote resources, or resolve navigation and media references. It powers [AAC Board AI](https://github.com/shayc/aac-board-ai) ([live app](https://aacboard.app)).
+## Features
 
-**Jump to:** [Choose an API](#choose-an-api) · [Usage](#usage) · [Validation behavior](#validation-behavior) · [API reference](#api-reference) · [Errors](#errors) · [Security](#security)
+- Load OBF or OBZ through one byte-based format detection API.
+- Create OBZ archives with generated manifests and validated media resources.
+- Use exported [Zod](https://zod.dev/) schemas and inferred TypeScript types.
+- Preserve unknown fields, including vendor extensions.
+- Run as pure ESM in Node.js 22+ and modern browsers.
+
+It focuses on board data and archives only. It does not render boards, play media, fetch remote resources, or resolve navigation and media references.
 
 ## Install
 
@@ -18,7 +22,7 @@ Pure ESM for Node.js 22+ and modern browsers. This package handles data and arch
 npm install @shayc/open-board-format zod
 ```
 
-`zod` `^4.4.3` is a required peer dependency. Installing it explicitly keeps setup consistent across package managers and lets this package share your application's Zod instance.
+`zod ^4.4.3` is a required peer dependency.
 
 ## Quick start
 
@@ -33,27 +37,12 @@ export async function loadRootBoard(input: BinaryInput): Promise<OBFBoard> {
 }
 ```
 
-`BinaryInput` is `File | Blob | ArrayBuffer | ArrayBufferView`, so browser files, fetched blobs, typed arrays, and Node.js `Buffer` values work directly. Detection uses the bytes, not the filename.
+`BinaryInput` accepts `File`, `Blob`, `ArrayBuffer`, and `ArrayBufferView` values, including browser files, fetched blobs, typed arrays, and Node.js `Buffer` values. `loadBoard` detects the format from the bytes, not the filename.
 
-## Choose an API
+## Formats
 
-| You have                                | Use                                          | Result                 |
-| --------------------------------------- | -------------------------------------------- | ---------------------- |
-| OBF JSON text                           | `parseOBF(json)`                             | Validated `OBFBoard`   |
-| An already-parsed unknown value         | `validateOBF(value)`                         | Validated `OBFBoard`   |
-| A known OBF `File`                      | `loadOBF(file)`                              | `Promise<OBFBoard>`    |
-| A known OBZ `File`                      | `loadOBZ(file, options?)`                    | `Promise<ParsedOBZ>`   |
-| OBZ binary data                         | `extractOBZ(input, options?)`                | `Promise<ParsedOBZ>`   |
-| OBF or OBZ binary data                  | `loadBoard(input, options?)`                 | `Promise<LoadedBoard>` |
-| Boards and optional media bytes         | `createOBZ(boards, rootBoardId, resources?)` | `Promise<Blob>`        |
-| Custom validation or schema composition | Exported `*Schema` values                    | Zod parse result       |
-
-Here, `File` means the Web Platform `File` object, not a filesystem path. For Node.js `Buffer` values or other binary input, use `loadBoard` for either format or `extractOBZ` for known OBZ input.
-
-## Formats at a glance
-
-- OBF (`.obf`) is one JSON communication board.
-- OBZ (`.obz`) is a ZIP package containing one or more boards and optional media.
+- **OBF (`.obf`)** is one JSON communication board.
+- **OBZ (`.obz`)** is a ZIP archive containing one or more boards and optional media.
 
 ```text
 my-board.obz
@@ -66,30 +55,41 @@ my-board.obz
     └── hello.mp3
 ```
 
-This library requires `manifest.json` at the archive root for every OBZ package, including packages containing one board.
+Every OBZ archive requires `manifest.json` at its root, even when it contains only one board.
 
-## Usage
+### Which function should I call?
 
-### Read an OBZ package
+- Unknown file: `loadBoard(input)`
+- Known `.obf` file: `loadOBF(file)`
+- Known `.obz` input: `extractOBZ(input)`
+- Creating an archive: `createOBZ(...)`
+
+See the [API reference](#api-reference) for the complete function list. Here, `File` means the Web Platform object, not a filesystem path.
+
+## Examples
+
+### Read an OBZ archive
 
 ```ts
 import { extractOBZ } from "@shayc/open-board-format";
-import type { BinaryInput, ParsedOBZ } from "@shayc/open-board-format";
 
-export function extractPackage(input: BinaryInput): Promise<ParsedOBZ> {
-  return extractOBZ(input);
-}
+const archive = await extractOBZ(obzBytes);
 ```
 
-- `rootBoard` is the board referenced by `manifest.root`.
-- `boards` is a `Map` keyed by board ID.
-- `resources` contains the raw bytes of every file entry, including `manifest.json`, board files, media, and unrelated extra files. Directory entries are omitted.
+The returned `ParsedOBZ` contains:
 
-For untrusted input, configure [extraction limits](#security) appropriate for your application.
+- `manifest`: the validated OBZ manifest.
+- `rootBoard`: the board referenced by `manifest.root`.
+- `boards`: a `Map` keyed by board ID.
+- `resources`: a `Map` containing the raw bytes of every file entry.
 
-### Create an OBZ package
+`resources` includes the manifest, board files, media, and unrelated extra files. Directory-marker entries are omitted.
 
-Buttons can reference media by ID. An entry in `images` or `sounds` can declare an archive `path`, and the `resources` map supplies the bytes for that path. `createOBZ` throws when a declared image or sound path has no matching resource.
+For untrusted archives, configure [extraction limits](#extraction-limits).
+
+### Create an OBZ archive
+
+Buttons reference media by ID. Image and sound records declare archive paths, while the `resources` map supplies the bytes stored at those paths.
 
 ```ts
 import { readFile, writeFile } from "node:fs/promises";
@@ -111,9 +111,11 @@ const blob = await createOBZ([board], "board-1", resources);
 await writeFile("my-board.obz", new Uint8Array(await blob.arrayBuffer()));
 ```
 
-The manifest is generated automatically. Boards are written to `boards/<encoded-id>.obf`, and `rootBoardId` selects the entry board. `createOBZ` checks duplicate board IDs, unknown roots, generated-path collisions, conflicting media paths, and missing declared media resources. It does not resolve `load_board` links or button-to-media references.
+`createOBZ` generates the manifest automatically, writes boards to `boards/<encoded-id>.obf`, and uses `rootBoardId` as the archive's entry board.
 
-### Use the schemas directly
+Before writing the archive, it checks board IDs, the root board, generated paths, media-path conflicts, and declared media resources. It does not resolve `load_board`, `image_id`, or `sound_id` references.
+
+### Validate a board
 
 ```ts
 import { OBFBoardSchema } from "@shayc/open-board-format";
@@ -122,82 +124,98 @@ export const validateBoard = (value: unknown) =>
   OBFBoardSchema.safeParse(value);
 ```
 
-Use Zod's `.extend()`, `.pick()`, or other composition APIs to build application-specific contracts from the exported schemas.
+Every public OBF data model has a matching Zod schema export with a `Schema` suffix. The schemas can also be composed with Zod APIs such as `.extend()` and `.pick()`.
 
 ## Validation behavior
 
-Validation returns a parsed copy and may normalize known fields:
+Validation returns a parsed copy of the input. Known fields may be normalized during parsing:
 
-- Numeric IDs are converted to strings.
+- Numeric IDs become strings.
 - Empty optional IDs, URLs, and email addresses become `undefined`.
-- Unknown properties are preserved at every loose-object level, whether or not they use the `ext_` prefix.
+- Unknown properties are preserved at every loose-object level, with or without an `ext_` prefix.
+
+Structural validation checks:
+
 - URL and email fields are syntax-checked.
-- Grid dimensions must be integers from 1 through 100, and `order` must exactly match `rows` and `columns`.
-- A positioned button must provide all four of `top`, `left`, `width`, and `height`, each from 0 through 1.
-- Format versions must match `open-board-*`; validation does not restrict them to `open-board-0.1`.
+- Grid dimensions must be integers from 1 through 100.
+- `grid.order` must exactly match the declared row and column counts.
+- Positioned buttons must provide `top`, `left`, `width`, and `height`, each between 0 and 1.
+- Format versions must match `open-board-*`; they are not restricted to `open-board-0.1`.
 - An OBZ manifest root must appear in `paths.boards`.
 
-Validation is structural, not a complete OBF conformance or graph-integrity check. It does not enforce:
+Validation is not a complete OBF conformance or graph-integrity check. It does not enforce:
 
 - Unique button, image, or sound IDs.
-- That `grid.order`, `image_id`, `sound_id`, or `load_board` references resolve.
-- That every button on a board uses the same positioning mode.
+- Resolution of `grid.order`, `image_id`, `sound_id`, or `load_board` references.
+- A consistent positioning mode across every button on a board.
 - BCP 47 locale syntax, color syntax, MIME correctness, or safe HTML.
-- During extraction, that manifest-declared media paths exist or agree with board media entries.
+- During extraction, the existence of manifest-declared media files or their agreement with board media records.
 
 Add application-specific checks after parsing when those guarantees matter.
 
 ## API reference
 
-### OBF
+### Functions
+
+#### Board data
 
 | Function              | Returns             | Behavior                                                    |
 | --------------------- | ------------------- | ----------------------------------------------------------- |
 | `parseOBF(json)`      | `OBFBoard`          | Parse JSON and validate a board; strips a leading UTF-8 BOM |
 | `validateOBF(value)`  | `OBFBoard`          | Validate and normalize an unknown value                     |
-| `stringifyOBF(board)` | `string`            | Two-space JSON serialization; does not revalidate           |
+| `stringifyOBF(board)` | `string`            | Serialize as two-space JSON without revalidating            |
 | `loadOBF(file)`       | `Promise<OBFBoard>` | Read a `File`, then parse and validate it                   |
 
-### OBZ
+#### Archives and format detection
 
-| Function                                     | Returns              | Behavior                                                            |
-| -------------------------------------------- | -------------------- | ------------------------------------------------------------------- |
-| `loadOBZ(file, options?)`                    | `Promise<ParsedOBZ>` | `File` convenience wrapper around `extractOBZ`                      |
-| `extractOBZ(input, options?)`                | `Promise<ParsedOBZ>` | Extract and validate the manifest and every manifest-declared board |
-| `createOBZ(boards, rootBoardId, resources?)` | `Promise<Blob>`      | Validate and package boards/resources with a generated manifest     |
-| `parseManifest(json)`                        | `OBFManifest`        | Parse and validate manifest JSON                                    |
+| Function                                     | Returns                | Behavior                                                            |
+| -------------------------------------------- | ---------------------- | ------------------------------------------------------------------- |
+| `loadBoard(input, options?)`                 | `Promise<LoadedBoard>` | Detect OBF or OBZ from the bytes, then load it                      |
+| `loadOBZ(file, options?)`                    | `Promise<ParsedOBZ>`   | `File` convenience wrapper around `extractOBZ`                      |
+| `extractOBZ(input, options?)`                | `Promise<ParsedOBZ>`   | Extract and validate the manifest and every manifest-declared board |
+| `createOBZ(boards, rootBoardId, resources?)` | `Promise<Blob>`        | Validate and package boards and resources with a generated manifest |
+| `parseManifest(json)`                        | `OBFManifest`          | Parse and validate manifest JSON                                    |
 
-`ParsedOBZ` is `{ manifest, boards, rootBoard, resources }`.
+#### ZIP utilities
 
-### Format detection
+| Function                  | Returns                            | Behavior                                                 |
+| ------------------------- | ---------------------------------- | -------------------------------------------------------- |
+| `isZip(buffer)`           | `boolean`                          | Check whether an `ArrayBuffer` has a ZIP signature       |
+| `zip(entries)`            | `Promise<Uint8Array>`              | Compress a map of paths to `Uint8Array` or `ArrayBuffer` |
+| `unzip(buffer, options?)` | `Promise<Map<string, Uint8Array>>` | Extract an `ArrayBuffer` and omit directory markers      |
 
-| Function                     | Returns                | Behavior                                                                                 |
-| ---------------------------- | ---------------------- | ---------------------------------------------------------------------------------------- |
-| `loadBoard(input, options?)` | `Promise<LoadedBoard>` | Sniff OBF vs OBZ, then return `{ format: "obf", board }` or `{ format: "obz", archive }` |
+### Types and schemas
 
-### ZIP utilities
+`LoadedBoard` is a discriminated union:
 
-| Function                  | Returns                            | Behavior                                                |
-| ------------------------- | ---------------------------------- | ------------------------------------------------------- |
-| `isZip(buffer)`           | `boolean`                          | Check only for the two-byte `PK` prefix                 |
-| `zip(entries)`            | `Promise<Uint8Array>`              | Compress a map of paths to `Uint8Array` / `ArrayBuffer` |
-| `unzip(buffer, options?)` | `Promise<Map<string, Uint8Array>>` | Extract an `ArrayBuffer`; omit directory-marker entries |
+```ts
+{ format: "obf", board: OBFBoard }
+  | { format: "obz", archive: ParsedOBZ }
+```
 
-### Exported types and schemas
+`ParsedOBZ` provides the validated archive contents:
 
-- **Boards and actions:** `OBFBoard`, `OBFGrid`, `OBFButton`, `OBFButtonAction`, `OBFSpellingAction`, `OBFSpecialtyAction`, `OBFLoadBoard`
-- **Media and metadata:** `OBFMedia`, `OBFImage`, `OBFSound`, `OBFSymbolInfo`, `OBFLicense`, `OBFID`, `OBFFormatVersion`, `OBFLocaleCode`, `OBFLocalizedStrings`, `OBFStrings`, `OBFManifest`
-- **Results and input:** `ParsedOBZ`, `LoadedBoard`, `BinaryInput`
-- **ZIP options:** `UnzipLimits`, `UnzipOptions`
-- **Errors:** `OBFError`, `OBFErrorInfo`, `OBFErrorCode`, `OBFIssue`
+```ts
+interface ParsedOBZ {
+  manifest: OBFManifest;
+  boards: Map<string, OBFBoard>;
+  rootBoard: OBFBoard;
+  resources: Map<string, Uint8Array>;
+}
+```
 
-Every board/media model type has a matching exported Zod schema with a `Schema` suffix: `OBFBoardSchema`, `OBFButtonSchema`, `OBFManifestSchema`, and so on. `ParsedOBZ`, `LoadedBoard`, binary/ZIP types, and error types do not have matching schemas.
+Main exports include:
 
-`OBFLocaleCode` is a locale string, typically BCP 47, but its syntax is not validated.
+- Board, action, media, metadata, and manifest types.
+- Matching Zod schemas, including `OBFBoardSchema` and `OBFManifestSchema`.
+- Input and archive types: `BinaryInput`, `ParsedOBZ`, and `LoadedBoard`.
+- Structured errors through `OBFError` and its related types.
 
-## Errors
+### Errors
 
-Expected parsing, validation, and archive-domain failures from the high-level functions use `OBFError`. Branch on `error.info.code`, not `error.message`.
+Expected parsing, validation, and archive-domain failures from the high-level APIs use `OBFError`.
+
+Branch on `error.info.code`, not `error.message`.
 
 ```ts
 import { loadBoard, OBFError } from "@shayc/open-board-format";
@@ -207,13 +225,21 @@ export async function openBoard(input: BinaryInput) {
   try {
     return await loadBoard(input);
   } catch (error) {
-    if (error instanceof OBFError) {
-      console.error(error.info.code, error.info);
+    if (!(error instanceof OBFError)) throw error;
+
+    if (error.info.code === "invalid-board") {
+      console.error(error.info.issues);
+    } else {
+      console.error(error.message);
     }
+
     throw error;
   }
 }
 ```
+
+<details>
+<summary><strong>Error codes</strong></summary>
 
 | Area           | `info.code`         | Additional fields                                  |
 | -------------- | ------------------- | -------------------------------------------------- |
@@ -234,21 +260,25 @@ export async function openBoard(input: BinaryInput) {
 | OBZ creation   | `zip-failed`        | —                                                  |
 | Internal       | `internal`          | `detail`                                           |
 
-- Validation failures put the `ZodError` on `error.cause` and its flat issue list on `error.info.issues`.
-- `not-json`, `unreadable-zip`, and `zip-failed` put the underlying parser or fflate error on `error.cause`.
-- `internal` indicates a library invariant failure that should be reported.
+</details>
 
-Schema `.parse()` calls throw `ZodError` directly; `NaN` limits throw `TypeError`, and native I/O, URI encoding, or JSON serialization errors can propagate.
+Validation failures expose the underlying `ZodError` as `error.cause` and provide its flat issue list through `error.info.issues`.
+
+`not-json`, `unreadable-zip`, and `zip-failed` expose the underlying parser or ZIP error as `error.cause`. An `internal` error indicates a library invariant failure and should be reported.
+
+Direct schema `.parse()` calls throw `ZodError` rather than `OBFError`.
 
 ## Security
 
 Treat OBZ archives and their contents as untrusted input.
 
+### Extraction limits
+
 ```ts
 import { extractOBZ } from "@shayc/open-board-format";
-import type { BinaryInput, ParsedOBZ } from "@shayc/open-board-format";
+import type { BinaryInput } from "@shayc/open-board-format";
 
-export function extractUntrusted(input: BinaryInput): Promise<ParsedOBZ> {
+export function extractUntrusted(input: BinaryInput) {
   return extractOBZ(input, {
     limits: {
       // Examples only—choose limits appropriate for your application.
@@ -260,34 +290,35 @@ export function extractUntrusted(input: BinaryInput): Promise<ParsedOBZ> {
 }
 ```
 
-The limits are optional and disabled by default. They are checked against sizes declared in ZIP metadata before inflation, and `maxEntries` caps the number of entries processed.
+Extraction limits are optional and disabled by default. Entry and total-size limits are checked against ZIP metadata before inflation, while `maxEntries` caps the number of entries processed.
 
-These are not hard memory guarantees for a malicious archive. ZIP metadata can be dishonest, and stored entries can produce more output than their declared uncompressed size. Also enforce an input archive-size limit outside this package; use isolation or a streaming design if your threat model requires a strict memory boundary.
+These limits reduce risk, but they are not strict memory guarantees. ZIP metadata can be dishonest, and stored entries can produce more output than their declared uncompressed size.
 
-Additional boundaries:
+Also enforce a limit on the compressed archive size before passing it to this package. Use process isolation or a streaming design when your threat model requires a strict memory boundary.
 
-- Archive entry paths are not sanitized. Validate them before writing entries to disk to prevent directory traversal.
+### Other boundaries
+
+- Archive entry paths are not sanitized. Validate them before writing files to disk to prevent directory traversal.
 - `description_html` is not sanitized. Sanitize it before inserting it into the DOM.
-- URLs and `data_url` values are validated syntactically but never fetched.
+- URLs and `data_url` values are validated syntactically but are never fetched.
 
 Found a vulnerability? Email [shayc@outlook.com](mailto:shayc@outlook.com) rather than opening a public issue.
 
-## Runtime and packaging
+## Runtime
 
-- Pure ESM; CommonJS is not supported.
-- Node.js `>=22`.
-- Modern browsers with `Blob`, `File`, `TextEncoder`, and `TextDecoder`.
-- Node versions 22, 24, and 26 are covered by CI; browser engines are not currently tested in CI.
-- `fflate` is the only runtime dependency. `zod ^4.4.3` is a peer dependency.
-- The v1.3.2 full-entry build is 9.6 kB gzip using tsdown 0.22.14, with `fflate` bundled and Zod externalized.
-- The package declares `sideEffects: false` and exposes one typed entry point.
+- Pure ESM for Node.js `>=22` and modern browsers; CommonJS is unsupported.
+- Browser environments must provide `Blob`, `File`, `TextEncoder`, and `TextDecoder`.
+- `fflate` is the only runtime dependency; `zod ^4.4.3` is a peer dependency.
+- CI covers Node.js 22, 24, and 26. Browser engines are not currently tested in CI.
 
 ## Project
 
-- **Versioning:** The public API follows semver; breaking changes to exported functions, types, schemas, or documented behavior ship as major versions. See [CHANGELOG.md](CHANGELOG.md).
+The public API follows semantic versioning. Breaking changes to exported APIs, schemas, or documented behavior ship as major releases.
+
+- **Changelog:** See [CHANGELOG.md](CHANGELOG.md).
 - **Support:** [Open an issue](https://github.com/shayc/open-board-format/issues) with a minimal reproduction, package version, runtime, and bundler where applicable.
 - **Contributing:** See [CONTRIBUTING.md](CONTRIBUTING.md) for development commands, tests, and the changeset workflow.
-- **Specification:** See the [official documentation](https://www.openboardformat.org/docs) or the included [offline mirror](docs/external/open-board-format.md).
+- **Specification:** See the [official OBF documentation](https://www.openboardformat.org/docs) or the included [offline mirror](docs/external/open-board-format.md).
 
 ## License
 


### PR DESCRIPTION
## Summary

- reorganize the README around fast package evaluation and API selection
- add concrete OBF/OBZ usage, validation, error, runtime, and security guidance
- clarify structural-validation and ZIP-limit boundaries
- add a patch changeset for the documentation update

## Why

The README is the package's primary documentation. This rewrite helps first-time developers and coding agents quickly decide whether the library fits their use case, while keeping the complete integration contract in one place.

## Developer impact

Consumers get a clearer quick start, a task-to-API map, copyable examples, and more precise documentation of normalization, native errors, archive resources, and security limitations. No runtime API changes are included.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` (164 tests)
- `npm run build`
- `npx publint`
