### PR TITLE
docs: polish project prose and comments

### DIFF
--- a/.changeset/quick-boards-shine.md
+++ b/.changeset/quick-boards-shine.md
@@ -1,0 +1,5 @@
+---
+"@shayc/open-board-format": patch
+---
+
+Polish public documentation and JSDoc for consistent terminology, clearer API boundaries, and faster scanning.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ const result = await loadBoard(input);
 
 `loadBoard` accepts a `File`, `Blob`, `ArrayBuffer`, or `ArrayBufferView` and detects the format from the bytes, not the filename. It returns a TypeScript discriminated union: OBF files contain a board directly, while OBZ files contain an archive whose `rootBoard` is the entry point.
 
+`File` refers to the Web API object, not a filesystem path.
+
 ```ts
 const board = result.format === "obf" ? result.board : result.archive.rootBoard;
 ```
@@ -87,7 +89,7 @@ import { createOBZ } from "@shayc/open-board-format";
 const obz = await createOBZ([board], board.id, resources);
 ```
 
-`createOBZ` generates the manifest automatically, writes boards to `boards/<encoded-id>.obf`, and uses `rootBoardId` as the archive's entry board.
+`createOBZ` generates the manifest automatically, writes boards to `boards/<encoded-id>.obf`, and uses `rootBoardId` as the archive's entry-point board.
 
 ### Validate a board
 
@@ -181,7 +183,7 @@ Main exports include:
 
 ### Errors
 
-Expected parsing, validation, and archive-domain failures from the high-level APIs use `OBFError`.
+High-level APIs report expected parsing, validation, and archive failures as `OBFError`.
 
 Branch on `error.info.code`, not `error.message`.
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,11 +1,10 @@
 /**
  * Typed errors for `@shayc/open-board-format`.
  *
- * Every failure thrown by this package is an {@link OBFError} carrying a
- * discriminated {@link OBFErrorInfo} on its `info` property. Switch on
- * `error.info.code` to get exactly the structured context for that failure —
- * the human-readable `message` is derived from `info` and is not part of the
- * stable contract.
+ * Expected parsing, validation, and archive failures use {@link OBFError}. Each
+ * carries a discriminated {@link OBFErrorInfo} on its `info` property. Switch
+ * on `error.info.code` for the structured context; the human-readable
+ * `message` is derived from `info` and is not part of the stable contract.
  *
  * ```ts
  * try {
@@ -40,7 +39,7 @@ export type OBFIssue = z.core.$ZodIssue;
  * Switch on `code`; each variant carries the fields relevant to it. When a
  * failure wraps an underlying error it lives on the standard `error.cause`,
  * never duplicated here. The only optional field is `invalid-board`'s
- * `boardId`, absent when validation runs on a value with no known id.
+ * `boardId`, absent when validation runs before a board `id` is known.
  */
 export type OBFErrorInfo =
   // --- decoding (underlying parser/decompressor error on `error.cause`) ---
@@ -82,7 +81,7 @@ export type OBFErrorInfo =
   | { code: "missing-manifest" }
   /** A board the manifest declares is absent from the archive. */
   | { code: "missing-board"; boardId: string; path: string }
-  /** A board's `id` disagrees with the id the manifest declares for it. */
+  /** A board's `id` disagrees with its manifest key. */
   | {
       code: "board-id-mismatch";
       path: string;
@@ -101,7 +100,7 @@ export type OBFErrorInfo =
       mediaId: string;
       path: string;
     }
-  /** Two boards declare the same media id with different paths. */
+  /** Two boards declare the same media ID with different paths. */
   | {
       code: "conflicting-paths";
       kind: "image" | "sound";
@@ -119,7 +118,7 @@ export type OBFErrorInfo =
 export type OBFErrorCode = OBFErrorInfo["code"];
 
 /**
- * The single error type thrown by `@shayc/open-board-format`.
+ * Structured error for expected failures from `@shayc/open-board-format`.
  *
  * Branch on {@link OBFError.info} (a discriminated {@link OBFErrorInfo}) rather
  * than parsing {@link OBFError.message}. Any underlying error — a `JSON.parse`

--- a/src/load-board.test.ts
+++ b/src/load-board.test.ts
@@ -130,7 +130,7 @@ describe("loadBoard", () => {
   });
 
   test("surfaces the OBZ extractor's error for a ZIP missing its manifest", async () => {
-    // A real ZIP so isZip passes and we exercise the OBZ branch, not the OBF one.
+    // Use a real ZIP so `isZip` selects the OBZ branch.
     const zipped = await zip(
       new Map([["boards/x.obf", new TextEncoder().encode("{}")]]),
     );

--- a/src/load-board.ts
+++ b/src/load-board.ts
@@ -18,7 +18,7 @@ import { isZip, toArrayBuffer } from "./zip";
  * ```ts
  * const loaded = await loadBoard(file);
  * if (loaded.format === "obz") {
- *   loaded.archive.rootBoard; // home board of the ParsedOBZ archive
+ *   loaded.archive.rootBoard; // entry-point board of the ParsedOBZ archive
  * } else {
  *   loaded.board;             // OBFBoard
  * }

--- a/src/obf.test.ts
+++ b/src/obf.test.ts
@@ -7,7 +7,7 @@ const validBoard = makeBoard({
   id: "test-board",
   buttons: [{ id: "btn-1", label: "Hello" }],
   grid: { rows: 1, columns: 1, order: [["btn-1"]] },
-  // ext_ keys are spec-blessed extension fields and must survive round-trip.
+  // Keys prefixed with `ext_` are spec-defined extensions and must round-trip.
   ext_speaker_color: "blue",
 });
 

--- a/src/obf.ts
+++ b/src/obf.ts
@@ -42,8 +42,7 @@ export function parseOBF(json: string): OBFBoard {
 /**
  * Read a `File` and parse its contents as a validated OBF board.
  *
- * This relies on the browser `File` API; for Node environments,
- * read the file to a string and pass it to {@link parseOBF} instead.
+ * For a `Blob`, `ArrayBuffer`, or typed-array input, use `loadBoard` instead.
  *
  * @param file - A `File` handle pointing to an `.obf` file.
  * @returns The validated board object.

--- a/src/obz.test.ts
+++ b/src/obz.test.ts
@@ -108,7 +108,7 @@ describe("extractOBZ", () => {
     expect(result.rootBoard).toBe(result.boards.get("b"));
   });
 
-  test("throws when a board's id does not match its manifest key", async () => {
+  test("throws when a board's ID does not match its manifest key", async () => {
     const manifest = JSON.stringify({
       format: "open-board-0.1",
       root: "boards/home.obf",
@@ -195,8 +195,8 @@ describe("extractOBZ", () => {
   });
 });
 
-// A one-line wrapper over extractOBZ: all it can get wrong is the File read or
-// dropping `options`, so both are asserted here and the rest is extractOBZ's.
+// This one-line wrapper can only drop `file` or `options`. Assert both here and
+// leave extraction behavior to `extractOBZ`.
 describe("loadOBZ", () => {
   test("reads a File and forwards limits to extraction", async () => {
     const obzBlob = await createOBZ([makeBoard({ id: "test" })], "test");
@@ -236,7 +236,7 @@ describe("createOBZ", () => {
     ).toMatchObject({ code: "unknown-root", rootBoardId: "wrong-id" });
   });
 
-  test("throws when two boards share the same id", async () => {
+  test("throws when two boards share the same ID", async () => {
     expect(
       await expectOBFErrorAsync(
         createOBZ([makeBoard({ id: "dup" }), makeBoard({ id: "dup" })], "dup"),
@@ -245,7 +245,7 @@ describe("createOBZ", () => {
   });
 
   test.each(["../evil", "a/b", "a\\b"])(
-    "percent-encodes path-like board ids into a safe filename (%s)",
+    "percent-encodes path-like board IDs into a safe filename (%s)",
     async (id) => {
       const blob = await createOBZ([makeBoard({ id })], id);
       const extracted = await extractOBZ(await blob.arrayBuffer());
@@ -261,7 +261,7 @@ describe("createOBZ", () => {
       format: "open-board-0.1",
       id: "bad",
       buttons: [],
-      // grid is required by OBFBoardSchema
+      // `grid` is required by `OBFBoardSchema`.
     } as unknown as OBFBoard;
 
     expect(
@@ -358,7 +358,7 @@ describe("createOBZ", () => {
     expect(extracted.manifest.paths.images).toEqual({});
   });
 
-  test("includes path-bearing media but skips url/data-only entries", async () => {
+  test("includes path-bearing media but skips `url`/`data`-only entries", async () => {
     const board = makeBoard({
       buttons: [{ id: "btn", image_id: "kept" }],
       grid: { rows: 1, columns: 1, order: [["btn"]] },
@@ -374,13 +374,13 @@ describe("createOBZ", () => {
       await (await createOBZ([board], "b", resources)).arrayBuffer(),
     );
 
-    // Only the path-bearing entry survives; url/data-only media are skipped.
+    // Only the path-bearing entry survives; `url`/`data`-only media are skipped.
     expect(extracted.manifest.paths.images).toStrictEqual({
       kept: "images/kept.png",
     });
   });
 
-  test("throws when two boards declare the same image id with conflicting paths", async () => {
+  test("throws when two boards declare the same image ID with conflicting paths", async () => {
     const board1 = makeBoard({
       id: "b1",
       images: [{ id: "shared", path: "images/a.png" }],
@@ -400,7 +400,7 @@ describe("createOBZ", () => {
     });
   });
 
-  test("throws when two boards declare the same sound id with conflicting paths", async () => {
+  test("throws when two boards declare the same sound ID with conflicting paths", async () => {
     const board1 = makeBoard({
       id: "b1",
       sounds: [{ id: "shared", path: "sounds/a.mp3" }],
@@ -453,7 +453,7 @@ describe("Integration: createOBZ and extractOBZ", () => {
 describe("Integration: Real-world OBZ package", () => {
   const FIXTURE = "lots-of-stuff.obz";
 
-  test("resolves all five boards keyed by manifest id, including id-mismatched filenames", async () => {
+  test("resolves all five boards keyed by manifest ID, including ID-mismatched filenames", async () => {
     const { boards } = await extractOBZ(readFixtureArrayBuffer(FIXTURE));
 
     expect(boards.size).toBe(5);
@@ -489,7 +489,7 @@ describe("Integration: Real-world OBZ package", () => {
       "9": "images/happy.png",
       "11": "images/sad.png",
     });
-    // Two distinct sound ids legitimately map to the same file.
+    // Two distinct sound IDs legitimately map to the same file.
     expect(manifest.paths.sounds).toEqual({
       sl3: "sounds/sigh.mp3",
       ss2: "sounds/sigh.mp3",
@@ -504,7 +504,7 @@ describe("Integration: Real-world OBZ package", () => {
 
     const happy = resources.get("images/happy.png");
     expect(happy?.byteLength).toBe(30987);
-    // PNG magic number — proves the bytes are the real decompressed image.
+    // The PNG signature confirms these are the decompressed image bytes.
     expect(Array.from(happy?.slice(0, 4) ?? [])).toEqual([
       0x89, 0x50, 0x4e, 0x47,
     ]);
@@ -536,7 +536,7 @@ describe("Integration: Real-world OBZ package", () => {
     expect(remote?.path).toBeUndefined();
   });
 
-  test("preserves mixed media reference styles and coerces numeric ids", async () => {
+  test("preserves mixed media reference styles and coerces numeric IDs", async () => {
     const { boards } = await extractOBZ(readFixtureArrayBuffer(FIXTURE));
 
     const linkedImages = boards.get("link")?.images ?? [];
@@ -549,7 +549,7 @@ describe("Integration: Real-world OBZ package", () => {
       filename: "hat.ico",
     });
 
-    // Numeric image ids in inline_images.obf are coerced to strings.
+    // Numeric image IDs in `inline_images.obf` are coerced to strings.
     const inlineImageIds = boards
       .get("inline_images")
       ?.images?.map((image) => image.id);

--- a/src/obz.ts
+++ b/src/obz.ts
@@ -60,7 +60,7 @@ export async function loadOBZ(
  *   declared uncompressed sizes, checked before inflation. No limits are
  *   applied by default.
  * @returns A {@link ParsedOBZ} with the archive's manifest, boards, root
- *          board, and resources.
+ *   board, and resources.
  *
  * @throws {@link OBFError}; branch on `info.code`: `"not-zip"`,
  *   `"unreadable-zip"`, `"archive-too-large"` (a limit in `options.limits` is
@@ -130,16 +130,23 @@ export function parseManifest(json: string): OBFManifest {
  * Every failure is an {@link OBFError}; branch on `info.code`.
  *
  * @param boards - The boards to include in the archive.
- * @param rootBoardId - The ID of the board that serves as the archive's entry point.
- * @param resources - Optional map of file paths to binary content (images, sounds, etc.).
+ * @param rootBoardId - The entry-point board's ID.
+ * @param resources - Optional map of archive paths to binary content.
  * @returns A `Blob` containing the compressed OBZ archive.
  *
- * @throws {@link OBFError} `"unknown-root"` if `rootBoardId` does not match any of the supplied boards.
- * @throws {@link OBFError} `"duplicate-board"` if two supplied boards share the same ID.
- * @throws {@link OBFError} `"invalid-board"` if a supplied board fails schema validation.
- * @throws {@link OBFError} `"conflicting-paths"` if two boards declare the same media ID with conflicting paths.
- * @throws {@link OBFError} `"missing-resource"` if a board declares an image or sound `path` with no matching entry in `resources`.
- * @throws {@link OBFError} `"path-collision"` if a `resources` entry would overwrite the generated `manifest.json` or a board file.
+ * @throws {@link OBFError} `"unknown-root"` if `rootBoardId` does not match any
+ *   supplied board.
+ * @throws {@link OBFError} `"duplicate-board"` if two supplied boards share
+ *   the same ID.
+ * @throws {@link OBFError} `"invalid-board"` if a supplied board fails schema
+ *   validation.
+ * @throws {@link OBFError} `"conflicting-paths"` if two boards map the same
+ *   media ID to different paths.
+ * @throws {@link OBFError} `"missing-resource"` if a board declares an image
+ *   or sound `path` with no matching entry in `resources`.
+ * @throws {@link OBFError} `"path-collision"` if a resource would overwrite
+ *   the generated manifest or a board file.
+ * @throws {@link OBFError} `"zip-failed"` if archive compression fails.
  */
 export async function createOBZ(
   boards: OBFBoard[],
@@ -235,24 +242,23 @@ export async function createOBZ(
 // ---------------------------------------------------------------------------
 
 /**
- * Derive a board's archive path from its id.
+ * Derive a board's archive path from its ID.
  *
- * Board ids are spec-legal as any non-empty string, but archive paths give
- * `/` and `\` structural meaning. Percent-encoding the id keeps the mapping
- * deterministic and collision-free without rejecting any id the schema
- * already allows — a `/` or `..` in the id just becomes part of a filename,
- * never a path segment.
+ * Board IDs may be any non-empty string, but archive paths give `/` and `\`
+ * structural meaning. Percent-encoding keeps the mapping deterministic and
+ * collision-free without rejecting any valid ID: `/` or `..` is encoded as
+ * filename text, never interpreted as a path segment.
  */
 function boardPath(id: string): string {
   return `boards/${encodeURIComponent(id)}.obf`;
 }
 
 /**
- * Walk every board's media collection and produce the `{ id -> path }` map
- * the spec calls "redundant but still required" for the OBZ manifest.
+ * Walk every board's media collection and produce the ID-to-path map the spec
+ * calls "redundant but still required" for the OBZ manifest.
  *
- * Throws when two boards declare the same media ID with conflicting paths
- * — a silent OBZ that points at a non-existent file is worse than a clear error.
+ * Throws when two boards map the same media ID to different paths. Without
+ * this check, the generated manifest could silently point to the wrong file.
  */
 function collectMediaPaths(
   boards: OBFBoard[],
@@ -286,8 +292,8 @@ function collectMediaPaths(
  * Assert that every media path the generated manifest declares exists as an
  * archive entry — the same contract {@link extractOBZ} assumes when reading.
  *
- * Only media that declared a `path` reach this check, so `url`/`data`-only
- * media are never flagged.
+ * Only media with a `path` reach this check, so `url`/`data`-only media are
+ * never flagged.
  */
 function assertPathsPresent(
   kind: "image" | "sound",

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -150,7 +150,7 @@ describe("OBFLicenseSchema", () => {
     expect(OBFLicenseSchema.safeParse(invalidEmail).success).toBe(false);
   });
 
-  test("coerces empty-string urls and email to undefined", () => {
+  test("coerces empty-string URLs and email to undefined", () => {
     const parsed = OBFLicenseSchema.parse({
       type: "CC-BY",
       copyright_notice_url: "",
@@ -178,13 +178,13 @@ describe("OBFMediaSchema", () => {
     expect(OBFMediaSchema.safeParse(validMedia).success).toBe(true);
   });
 
-  test("accepts media with only id (reference is optional)", () => {
+  test("accepts media with only `id` (reference is optional)", () => {
     const minimalMedia = { id: "x" };
 
     expect(OBFMediaSchema.safeParse(minimalMedia).success).toBe(true);
   });
 
-  test("coerces numeric id to string in nested object", () => {
+  test("coerces numeric `id` to string in nested object", () => {
     const result = OBFMediaSchema.parse({ id: 123 });
 
     expect(result.id).toBe("123");
@@ -237,13 +237,13 @@ describe("OBFButtonSchema", () => {
     expect(OBFButtonSchema.safeParse(withExtAction).success).toBe(true);
   });
 
-  test("rejects missing id", () => {
+  test("rejects missing `id`", () => {
     const missingId = { label: "Hello" };
 
     expect(OBFButtonSchema.safeParse(missingId).success).toBe(false);
   });
 
-  // Wiring only — the action grammar itself is covered by the action schema suites.
+  // Wiring only; the action schema suites cover the grammar.
   test("rejects an invalid action in both `action` and `actions`", () => {
     expect(
       OBFButtonSchema.safeParse({ id: "1", action: "hello" }).success,
@@ -339,7 +339,7 @@ describe("OBFButtonSchema", () => {
     expect(OBFButtonSchema.safeParse(invalidLoadBoardUrl).success).toBe(false);
   });
 
-  test("coerces empty-string media ids to undefined", () => {
+  test("coerces empty-string media IDs to undefined", () => {
     const parsed = OBFButtonSchema.parse({
       id: "1",
       image_id: "",

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -48,7 +48,7 @@ export type OBFFormatVersion = z.infer<typeof OBFFormatVersionSchema>;
  */
 export const OBFLocaleCodeSchema = z.string();
 
-/** Locale identifier, typically a BCP 47 language tag, e.g., `en`, `en-US`. See {@link OBFLocaleCodeSchema}. */
+/** Locale identifier, typically a BCP 47 language tag; accepts any string. See {@link OBFLocaleCodeSchema}. */
 export type OBFLocaleCode = z.infer<typeof OBFLocaleCodeSchema>;
 
 /**
@@ -120,7 +120,8 @@ export type OBFLicense = z.infer<typeof OBFLicenseSchema>;
 /**
  * Common properties for media resources (images and sounds).
  *
- * When multiple references are provided, they should be used in the following order:
+ * Resolve multiple references in this order:
+ *
  * 1. `data`
  * 2. `path`
  * 3. `url`
@@ -167,7 +168,8 @@ export type OBFSymbolInfo = z.infer<typeof OBFSymbolInfoSchema>;
  * Image resource, extending {@link OBFMediaSchema} with optional
  * symbol and dimension properties.
  *
- * When resolving the image, consumers should prefer sources in this order:
+ * Resolve multiple image sources in this order:
+ *
  * 1. `data`
  * 2. `path`
  * 3. `url`
@@ -214,7 +216,7 @@ export const OBFLoadBoardSchema = z.looseObject({
 export type OBFLoadBoard = z.infer<typeof OBFLoadBoardSchema>;
 
 /**
- * Interactive element on a board, optionally linked to images, sounds, and actions.
+ * Interactive board element, optionally linked to images, sounds, and actions.
  */
 export const OBFButtonSchema = z
   .looseObject({
@@ -241,22 +243,21 @@ export const OBFButtonSchema = z
     /** Information to load another board when this button is activated. */
     load_board: OBFLoadBoardSchema.optional(),
     /**
-     * Background color of the button, typically `rgb`/`rgba`. Not
-     * strictly validated — any string is accepted.
+     * Background color, typically an `rgb()` or `rgba()` value. Accepts any
+     * string.
      */
     background_color: z.string().optional(),
     /**
-     * Border color of the button, typically `rgb`/`rgba`. Not strictly
-     * validated — any string is accepted.
+     * Border color, typically an `rgb()` or `rgba()` value. Accepts any string.
      */
     border_color: z.string().optional(),
-    /** Vertical position for absolute positioning (0.0 to 1.0). */
+    /** Vertical position for absolute positioning, from 0 to 1. */
     top: z.number().min(0).max(1).optional(),
-    /** Horizontal position for absolute positioning (0.0 to 1.0). */
+    /** Horizontal position for absolute positioning, from 0 to 1. */
     left: z.number().min(0).max(1).optional(),
-    /** Width of the button for absolute positioning (0.0 to 1.0). */
+    /** Width of the button for absolute positioning, from 0 to 1. */
     width: z.number().min(0).max(1).optional(),
-    /** Height of the button for absolute positioning (0.0 to 1.0). */
+    /** Height of the button for absolute positioning, from 0 to 1. */
     height: z.number().min(0).max(1).optional(),
   })
   .refine(
@@ -272,12 +273,9 @@ export const OBFButtonSchema = z
     },
   );
 
-/** Interactive element on a board, optionally linked to images, sounds, and actions. See {@link OBFButtonSchema}. */
+/** Interactive board element, optionally linked to images, sounds, and actions. See {@link OBFButtonSchema}. */
 export type OBFButton = z.infer<typeof OBFButtonSchema>;
 
-/**
- * Row-and-column layout that arranges buttons by their IDs.
- */
 /**
  * Upper bound on grid dimensions. A board only needs these to lay out cells;
  * a consumer allocates rows × columns, so an unbounded value (e.g. 1e9) would
@@ -287,16 +285,14 @@ export type OBFButton = z.infer<typeof OBFButtonSchema>;
 const MAX_GRID_ROWS = 100;
 const MAX_GRID_COLUMNS = 100;
 
+/** Row-and-column layout that arranges buttons by their IDs. */
 export const OBFGridSchema = z
   .looseObject({
     /** Number of rows in the grid. */
     rows: z.number().int().min(1).max(MAX_GRID_ROWS),
     /** Number of columns in the grid. */
     columns: z.number().int().min(1).max(MAX_GRID_COLUMNS),
-    /**
-     * 2D array representing the order of buttons by their IDs.
-     * Each sub-array corresponds to a row, and each element is a button ID or null for empty slots.
-     */
+    /** Button IDs by row; `null` marks an empty cell. */
     order: z.array(z.array(z.union([OBFIDSchema, z.null()]))),
   })
   .refine((g) => g.order.length === g.rows, {
@@ -317,7 +313,7 @@ export const OBFBoardSchema = z.looseObject({
   format: OBFFormatVersionSchema,
   /** Unique identifier for the board. */
   id: OBFIDSchema,
-  /** Locale of the board as a BCP 47 language tag, e.g., `en`, `en-US`. */
+  /** Locale identifier, typically a BCP 47 language tag such as `en` or `en-US`. */
   locale: OBFLocaleCodeSchema.optional(),
   /** List of buttons on the board. */
   buttons: z.array(OBFButtonSchema),

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -212,7 +212,8 @@ describe("unzip limits", () => {
   });
 
   test("rejects promptly when a limit trips after a large entry started inflating asynchronously", async () => {
-    // 600,000 zeros: over fflate's 512 KB sync-inflate threshold, so an async worker is dispatched.
+    // This exceeds fflate's 512 KB synchronous-inflate threshold and starts an
+    // asynchronous worker.
     const zipped = await zip(filesOf(600_000, 100));
     const info = await expectOBFErrorAsync(
       unzip(bytesToArrayBuffer(zipped), {
@@ -253,7 +254,8 @@ describe("unzip limits", () => {
   );
 
   test("rejects with unreadable-zip, not archive-too-large, when a synchronously-inflated corrupt entry precedes a limit trip", async () => {
-    // Both entries stay under fflate's 512 KB sync-inflate threshold; see the terminate() comment in unzip() for the async case this doesn't cover.
+    // Both entries stay below fflate's 512 KB synchronous-inflate threshold.
+    // The `terminate()` comment in `unzip()` covers the asynchronous case.
     const zipped = await zip(filesOf(1_000, 200_000));
     const buffer = bytesToArrayBuffer(zipped);
     const bytes = new Uint8Array(buffer);
@@ -263,7 +265,7 @@ describe("unzip limits", () => {
     const dataStart = 30 + view.getUint16(26, true) + view.getUint16(28, true);
     bytes.fill(0xff, dataStart + 2, dataStart + 10);
 
-    // Sanity control: without limits, the corruption alone causes unreadable-zip.
+    // Control: without limits, the corruption alone causes `unreadable-zip`.
     expect((await expectOBFErrorAsync(unzip(buffer))).code).toBe(
       "unreadable-zip",
     );

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -10,8 +10,8 @@ import { OBFError } from "./errors";
  * First two bytes of every ZIP archive — the ASCII letters `PK`,
  * after Phil Katz, creator of the format.
  *
- * Only the 2-byte prefix is checked intentionally: this keeps the
- * test lightweight and sufficient for distinguishing ZIP from JSON.
+ * Only the 2-byte prefix is checked intentionally: this keeps detection
+ * lightweight and is sufficient for distinguishing ZIP from JSON.
  */
 const ZIP_MAGIC = [0x50, 0x4b] as const;
 
@@ -48,10 +48,9 @@ export async function toArrayBuffer(input: BinaryInput): Promise<ArrayBuffer> {
 }
 
 /**
- * Optional caps on declared uncompressed sizes, checked per entry against the
- * archive's ZIP metadata before that entry is inflated. Entries accepted
- * before a later entry trips a limit have already been inflated, but total
- * allocation stays bounded by the caps.
+ * Optional caps on declared uncompressed sizes, checked against ZIP metadata
+ * before each entry is inflated. These limits reduce allocation risk but are
+ * not strict memory guarantees because archive metadata can be dishonest.
  */
 export interface UnzipLimits {
   /** Max declared uncompressed size of any single entry, in bytes. */
@@ -113,7 +112,7 @@ export function unzip(
 
     const filter = (file: UnzipFileInfo): boolean => {
       if (limitError) {
-        return false; // limit tripped: skip the rest cheaply
+        return false; // Skip the remaining entries cheaply.
       }
 
       entryCount += 1;
@@ -186,9 +185,10 @@ export function unzip(
 
     if (limitError) {
       const error = limitError;
-      // Deliberate: this can pre-empt an in-flight entry's own corruption error, surfacing archive-too-large instead of unreadable-zip.
-      terminate(); // kill any dispatched async inflate workers
-      // Deferred so an archive error fflate queued during its sync pass settles first.
+      // This deliberately lets archive-too-large pre-empt an in-flight entry's
+      // corruption error.
+      terminate(); // Stop any dispatched asynchronous inflate workers.
+      // Defer so an archive error from fflate's synchronous pass settles first.
       queueMicrotask(() => {
         if (!settled) {
           settled = true;


### PR DESCRIPTION
## Summary

- clarify API boundaries and error behavior
- tighten public JSDoc and repair the OBFGridSchema documentation attachment
- standardize terminology and high-signal test comments

## Validation

- npm run format:check
- npm run lint
- npm run typecheck
- npm test
- npm run build